### PR TITLE
GOVSI-943: Put correct value in the `*-bucket` parameters

### DIFF
--- a/ci/terraform/parameters.tf
+++ b/ci/terraform/parameters.tf
@@ -75,7 +75,7 @@ resource "aws_ssm_parameter" "phone" {
 resource "aws_ssm_parameter" "sms_bucket" {
   name   = "${local.smoke_tester_name}-bucket"
   type   = "SecureString"
-  value  = var.phone
+  value  = local.sms_bucket_name
   key_id = aws_kms_alias.parameter_store_key_alias.id
 
   tags = local.default_tags

--- a/ci/terraform/shared.tf
+++ b/ci/terraform/shared.tf
@@ -10,4 +10,5 @@ data "terraform_remote_state" "shared" {
 
 locals {
   sms_bucket_name_arn = data.terraform_remote_state.shared.outputs.sms_bucket_name_arn
+  sms_bucket_name = data.terraform_remote_state.shared.outputs.sms_bucket_name
 }


### PR DESCRIPTION
## What?

- Put bucket name in the `*-bucket` parameter

## Why?

We were inadvertently putting the phone number in the bucket parameter rather than the bucket name