### PR TITLE
GOVSI-943: Add path to heartbeat lambda

### DIFF
--- a/ci/tasks/deploy.yml
+++ b/ci/tasks/deploy.yml
@@ -45,6 +45,7 @@ run:
         -var "dns_state_key=${DNS_STATE_KEY}" \
         -var "dns_state_role=${DNS_DEPLOYER_ROLE_ARN}" \
         -var "environment=${DEPLOY_ENVIRONMENT}" \
+        -var "heartbeat_lambda_zip_file=../../../smoke-test-release/hearbeat.zip" \
         -var "password=${SMOKETESTER_PASSWORD}" \
         -var "phone=${SMOKETESTER_PHONE}" \
         -var "shared_state_bucket=${STATE_BUCKET}" \


### PR DESCRIPTION
## What?

- Add path to heartbeat lambda

## Why?

Deploy is failing because path is wrong
