### PR TITLE
GOVSI-619: update pagerduty alert descriptions and change thresholds

### DIFF
--- a/ci/terraform/alarm.tf
+++ b/ci/terraform/alarm.tf
@@ -5,32 +5,32 @@ resource "aws_cloudwatch_metric_alarm" "smoke_tester_metric_alarm_p1" {
   evaluation_periods  = "1"
   metric_name         = "Failed"
   namespace           = "CloudWatchSynthetics"
-  period              = "300"
+  period              = "600"
   statistic           = "Sum"
-  threshold           = "2"
+  threshold           = "3"
 
   dimensions = {
     CanaryName = aws_synthetics_canary.smoke_tester.name
   }
 
-  alarm_description = "Monitor smoke-tester P1 failures"
+  alarm_description = "GOV.UK Sign in - ${local.smoke_tester_name} P1 failure"
   alarm_actions     = [aws_sns_topic.pagerduty_p1_alerts.arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "smoke_tester_metric_alarm_p2" {
   alarm_name          =  "${local.smoke_tester_name}-metric-alarm_p2"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = "3"
   metric_name         = "Failed"
   namespace           = "CloudWatchSynthetics"
-  period              = "300"
+  period              = "600"
   statistic           = "Sum"
-  threshold           = "2"
+  threshold           = "5"
 
   dimensions = {
     CanaryName = aws_synthetics_canary.smoke_tester.name
   }
 
-  alarm_description = "Monitor smoke-tester P2 failures"
+  alarm_description = "GOV.UK Sign in - ${local.smoke_tester_name} P2 failure"
   alarm_actions     = [aws_sns_topic.pagerduty_p2_alerts.arn]
 }

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -60,7 +60,7 @@ variable "smoke_test_lambda_zip_file" {
 }
 
 variable "smoke_test_rate_minutes" {
-  default     = 5
+  default     = 3
   description = "Minutes between smoke test executions"
   type        = number
 }


### PR DESCRIPTION
## What

Update Pagerduty alert descriptions and change thresholds.

Send a meaningful description to Pagerduty when alerting.  Getting Pagerduty to use this means updating the Pagerduty integration itself to use the description field.

Make the smoke tester run every 3 mins.

For a P1 require 3 failures in 10 mins.
For a P2 require 5 failures in 30 mins (catch longer running intermittent failures that don't trigger a P1).

Not sure if we know what a P2 is at the moment but the infrastructure is there to support it.
