### PR TITLE
BAU: remove integration smoke test pager duty alerts

### DIFF
--- a/ci/terraform/pagerduty.tf
+++ b/ci/terraform/pagerduty.tf
@@ -37,18 +37,21 @@ data "aws_iam_policy_document" "pagerduty_alerts_policy_document" {
 }
 
 resource "aws_sns_topic_subscription" "pagerduty_p1_alerts_topic_subscription" {
+  count     = var.environment == "production" ? 1 : 0
   topic_arn = aws_sns_topic.pagerduty_p1_alerts.arn
   protocol  = "https"
   endpoint  = var.pagerduty_p1_alerts_endpoint
 }
 
 resource "aws_sns_topic_subscription" "pagerduty_p2_alerts_topic_subscription" {
+  count     = var.environment == "production" ? 1 : 0
   topic_arn = aws_sns_topic.pagerduty_p2_alerts.arn
   protocol  = "https"
   endpoint  = var.pagerduty_p2_alerts_endpoint
 }
 
 resource "aws_sns_topic_subscription" "pagerduty_cronitor_alerts_topic_subscription" {
+  count     = var.environment == "production" ? 1 : 0
   topic_arn = aws_sns_topic.pagerduty_cronitor_alerts.arn
   protocol  = "https"
   endpoint  = var.pagerduty_cronitor_alerts_endpoint


### PR DESCRIPTION

## What?

Remove integration smoke test pager duty alerts

Remove pagerduty sns subscription from the alarm.

## Why?

Pagerduty integration was configured for both production and integration, so integration smoke test failures were alerted as production issues.

Removing the SNS resources rather than leave the endpoint blank.
