### PR TITLE
BAU: Provision smoketest user in Terraform

### DIFF
--- a/ci/tasks/deploy.yml
+++ b/ci/tasks/deploy.yml
@@ -28,6 +28,7 @@ params:
 inputs:
   - name: src
   - name: smoke-test-release
+  - name: hashed-password
 outputs:
   - name: terraform-outputs
 run:
@@ -53,6 +54,7 @@ run:
         -var "environment=${DEPLOY_ENVIRONMENT}" \
         -var "heartbeat_lambda_zip_file=../../../smoke-test-release/heartbeat.zip" \
         -var "password=${SMOKETESTER_PASSWORD}" \
+        -var "hashed_password=$(hashed-password/hashed-password.txt)" \
         -var "phone=${SMOKETESTER_PHONE}" \
         -var "basic_auth_username=${BASIC_AUTH_USERNAME}" \
         -var "basic_auth_password=${BASIC_AUTH_PASSWORD}" \

--- a/ci/tasks/prepare-password-hash.yml
+++ b/ci/tasks/prepare-password-hash.yml
@@ -1,0 +1,20 @@
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: ((readonly_private_ecr_repo_name))
+    tag: di-toolbox-latest
+    aws_access_key_id: ((readonly_access_key_id))
+    aws_secret_access_key: ((readonly_secret_access_key))
+    aws_session_token: ((readonly_session_token))
+    aws_region: eu-west-2
+params:
+  SMOKETESTER_PASSWORD: ((smoke-tester-password-integration))
+outputs:
+  - name: hashed-password
+run:
+  path: /bin/bash
+  args:
+    - -euc
+    - |
+      echo -n "${SMOKETESTER_PASSWORD}" | argon2 $(openssl rand -hex 32) -e -id -v 13 -k 15360 -t 2 -p 1 > hashed-password/hashed-password.txt

--- a/ci/terraform/.terraform.lock.hcl
+++ b/ci/terraform/.terraform.lock.hcl
@@ -19,3 +19,40 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:f5638a533cf9444f7d02b5527446cdbc3b2eab8bcc4ec4b0ca32035fe6f479d3",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.1.0"
+  hashes = [
+    "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
+    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
+    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
+    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
+    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
+    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
+    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
+    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
+    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
+    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
+    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
+    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.7.2"
+  constraints = "0.7.2"
+  hashes = [
+    "h1:NKy1QrNLlP5mKy5Tea6lQSRsVoyydJQKh6WvNTdBF4I=",
+    "zh:0bbe0158c2a9e3f5be911b7e94477586110c51746bb13d102054f22754565bda",
+    "zh:3250af7fd49b8aaf2ccc895588af05197d886e38b727e3ba33bcbb8cc96ad34d",
+    "zh:35e4de0437f4fa9c1ad69aaf8136413be2369ea607d78e04bb68dc66a6a520b8",
+    "zh:369756417a6272e79cad31eb2c82c202f6a4b6e4204a893f656644ba9e149fa2",
+    "zh:390370f1179d89b33c3a0731691e772d5450a7d59fc66671ec625e201db74aa2",
+    "zh:3d12ac905259d225c685bc42e5507ed0fbdaa5a09c30dce7c1932d908df857f7",
+    "zh:75f63e5e1c68e6c5bccba4568c3564e2774eb3a7a19189eb8e2b6e0d58c8f8cc",
+    "zh:7c22a2078a608e3e0278c4cbc9c483909062ebd1843bddaf8f176346c6d378b1",
+    "zh:7cfb3c02f78f0060d59c757c4726ab45a962ce4a9cf4833beca704a1020785bd",
+    "zh:a0325917f47c28a2ed088dedcea0d9520d91b264e63cc667fe4336ac993c0c11",
+    "zh:c181551d4c0a40b52e236f1755cc340aeca0fb5dcfd08b3b1c393a7667d2f327",
+  ]
+}

--- a/ci/terraform/site.tf
+++ b/ci/terraform/site.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 3.54.0"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = "0.7.2"
+    }
   }
 
   backend "s3" {
@@ -19,6 +23,8 @@ provider "aws" {
     role_arn = var.deployer_role_arn
   }
 }
+
+provider "time" {}
 
 locals {
   // Using a local rather than the default_tags option on the AWS provider, as the latter has known issues which produce errors on apply.

--- a/ci/terraform/user.tf
+++ b/ci/terraform/user.tf
@@ -1,0 +1,99 @@
+data "aws_dynamodb_table" "user_credential_table" {
+  name = "${var.environment}-user-credentials"
+}
+
+data "aws_dynamodb_table" "user_profile_table" {
+  name = "${var.environment}-user-profile"
+}
+
+resource "time_static" "create_date" {
+  triggers = {
+    username = var.username
+  }
+}
+
+locals {
+  create_date = formatdate("YYYY-MM-DD'T'hh:mm:ss.000000", time_static.create_date.rfc3339)
+}
+
+resource "random_string" "subject_id" {
+  keepers = {
+    username = var.username
+  }
+  lower   = true
+  upper   = true
+  special = false
+  number  = true
+  length  = 32
+}
+
+resource "random_string" "public_subject_id" {
+  lower   = true
+  upper   = true
+  special = false
+  number  = true
+  length  = 32
+}
+
+resource "aws_dynamodb_table_item" "user_credential" {
+  table_name = data.aws_dynamodb_table.user_credential_table.name
+  hash_key   = data.aws_dynamodb_table.user_credential_table.hash_key
+  item = jsonencode({
+    "Email" = {
+      "S" = var.username
+    },
+    "Updated" = {
+      "S" = local.create_date
+    },
+    "SubjectID" = {
+      "S" = random_string.subject_id.result
+    },
+    "Password" = {
+      "S" = var.hashed_password
+    },
+    "Created" = {
+      "S" = formatdate("YYYY-MM-DD'T'hh:mm:ss.000000", time_static.create_date.rfc3339)
+    }
+  })
+}
+
+resource "aws_dynamodb_table_item" "user_profile" {
+  table_name = data.aws_dynamodb_table.user_profile_table.name
+  hash_key   = data.aws_dynamodb_table.user_profile_table.hash_key
+  item = jsonencode({
+    "Email" = {
+      "S" = var.username
+    },
+    "EmailVerified" = {
+      "N" = "1"
+    },
+    "PhoneNumberVerified" = {
+      "N" = "1"
+    },
+    "SubjectID" = {
+      "S" = random_string.subject_id.result
+    },
+    "PhoneNumber" = {
+      "S" = var.phone
+    },
+    "PublicSubjectID" = {
+      "S" = random_string.public_subject_id.result
+    },
+    "termsAndConditions" = {
+      "M" = {
+        "version" = {
+          "S" = var.terms_and_conditions_version
+        },
+        "timestamp" = {
+          "S" = local.create_date
+        }
+      }
+    },
+    "Updated" = {
+      "S" = local.create_date
+    },
+    "Created" = {
+      "S" = local.create_date
+    }
+  })
+}

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -55,6 +55,11 @@ variable "password" {
   type = string
 }
 
+variable "hashed_password" {
+  type        = string
+  description = "The hashed version of the password"
+}
+
 variable "phone" {
   type = string
 }
@@ -98,4 +103,8 @@ variable "basic_auth_username" {
 variable "basic_auth_password" {
   type    = string
   default = null
+}
+
+variable "terms_and_conditions_version" {
+  default = "1.1"
 }


### PR DESCRIPTION
## What?

- Add a task to prepare a password hash
- Pass the hash as a Terraform variable
- Write the smoke test user and password details to Dynamo using Terraform

## Why?

To make updating of password and accepted T&Cs version easier

## Related PRs

https://github.com/alphagov/di-infrastructure/pull/112
