### PR TITLE
BAU: Fix path to hashed-password.txt

### DIFF
--- a/ci/tasks/deploy.yml
+++ b/ci/tasks/deploy.yml
@@ -54,7 +54,7 @@ run:
         -var "environment=${DEPLOY_ENVIRONMENT}" \
         -var "heartbeat_lambda_zip_file=../../../smoke-test-release/heartbeat.zip" \
         -var "password=${SMOKETESTER_PASSWORD}" \
-        -var "hashed_password=$(hashed-password/hashed-password.txt)" \
+        -var "hashed_password=$(cat ../../../hashed-password/hashed-password.txt)" \
         -var "phone=${SMOKETESTER_PHONE}" \
         -var "basic_auth_username=${BASIC_AUTH_USERNAME}" \
         -var "basic_auth_password=${BASIC_AUTH_PASSWORD}" \


### PR DESCRIPTION
## What?

- Add missing `cat` command
- Amend path to `hashed-password.txt`

## Why?

The deploy task is failing in the pipeline