### PR TITLE
AUT-829: Set 'SmokeTest' flag in smoke test clients

### DIFF
--- a/ci/terraform/integration-stub-clients.tfvars
+++ b/ci/terraform/integration-stub-clients.tfvars
@@ -10,6 +10,7 @@ stub_rp_clients = [
       "http://localhost:3031/signed-out",
     ]
     test_client                     = "1"
+    smoke_test                      = "1"
     consent_required                = "0"
     identity_verification_supported = "1"
     client_type                     = "web"

--- a/ci/terraform/production-stub-clients.tfvars
+++ b/ci/terraform/production-stub-clients.tfvars
@@ -10,6 +10,7 @@ stub_rp_clients = [
       "http://localhost:3031/signed-out",
     ]
     test_client                     = "1"
+    smoke_test                      = "1"
     consent_required                = "0"
     identity_verification_supported = "1"
     client_type                     = "web"

--- a/ci/terraform/sandpit-stub-clients.tfvars
+++ b/ci/terraform/sandpit-stub-clients.tfvars
@@ -10,6 +10,7 @@ stub_rp_clients = [
       "http://localhost:3031/signed-out",
     ]
     test_client                     = "1"
+    smoke_test                      = "1"
     consent_required                = "0"
     identity_verification_supported = "1"
     client_type                     = "web"

--- a/ci/terraform/stub-rp-clients.tf
+++ b/ci/terraform/stub-rp-clients.tf
@@ -92,5 +92,8 @@ resource "aws_dynamodb_table_item" "stub_rp_client" {
     TestClient = {
       N = var.stub_rp_clients[count.index].test_client
     }
+    SmokeTest = {
+      N = var.stub_rp_clients[count.index].smoke_test
+    }
   })
 }

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -169,7 +169,7 @@ variable "issuer_base_url" {
 
 variable "stub_rp_clients" {
   default     = []
-  type        = list(object({ client_name : string, callback_urls : list(string), logout_urls : list(string), test_client : string, scopes : list(string), client_type : string, identity_verification_supported : string, consent_required : string }))
+  type        = list(object({ client_name : string, callback_urls : list(string), logout_urls : list(string), test_client : string, smoke_test : string, scopes : list(string), client_type : string, identity_verification_supported : string, consent_required : string }))
   description = "The details of RP clients to provision in the Client table"
 }
 


### PR DESCRIPTION
## What?

Set 'SmokeTest' flag in smoke test clients.

## Why?

Indicate to the application that the client running tests is a smoke tester.
Allows the smoke tester to test using test numbers.

## Related PRs

https://github.com/alphagov/di-authentication-api/pull/2776
