### PR TITLE
[AUT-2306] Update terraform provider locks, fix deprecations and add helper scripts

### DIFF
--- a/ci/terraform/.terraform.lock.hcl
+++ b/ci/terraform/.terraform.lock.hcl
@@ -5,7 +5,11 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.34.0"
   constraints = "5.34.0"
   hashes = [
+    "h1:1UEoNI8LGCKvrl0+60qYm0wY8uOoKmF0W+HnuAI1U4k=",
     "h1:1Y1JgV1z99QqAK06+atyfNqreZxyGZKbm4mZO4VhhT8=",
+    "h1:CUCoX4ax5hrP6BH4973oP+hgz8VR2GuNPQil3FYwEqQ=",
+    "h1:Tbq6dKE+XyXmkup6+7eQj2vH+eCJipk8R3VXhebVYi4=",
+    "h1:YSSLSKX6xN6NM2SeqKKpzvQyp6XVx9z1n3CVXwDLznQ=",
     "zh:01bb20ae12b8c66f0cacec4f417a5d6741f018009f3a66077008e67cce127aa4",
     "zh:3b0c9bdbbf846beef2c9573fc27898ceb71b69cf9d2f4b1dd2d0c2b539eab114",
     "zh:5226ecb9c21c2f6fbf1d662ac82459ffcd4ad058a9ea9c6200750a21a80ca009",
@@ -27,7 +31,11 @@ provider "registry.terraform.io/hashicorp/aws" {
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.6.0"
   hashes = [
+    "h1:5KeoKSVKVHJW308uiTgslxFbjQAdWzBGUFK68vgMRWY=",
     "h1:I8MBeauYA8J8yheLJ8oSMWqB0kovn16dF/wKZ1QTdkk=",
+    "h1:R5Ucn26riKIEijcsiOMBR3uOAjuOMfI1x7XvH4P6B1w=",
+    "h1:p6WG1IPHnqx1fnJVKNjv733FBaArIugqy58HRZnpPCk=",
+    "h1:t0mRdJzegohRKhfdoQEJnv3JRISSezJRblN0HIe67vo=",
     "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
     "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
     "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",
@@ -47,7 +55,11 @@ provider "registry.terraform.io/hashicorp/time" {
   version     = "0.10.0"
   constraints = ">= 0.10.0"
   hashes = [
+    "h1:EeF/Lb4db1Kl1HEHzT1StTC7RRqHn/eB7aDR3C3yjVg=",
     "h1:NAl8eupFAZXCAbE5uiHZTz+Yqler55B3fMG+jNPrjjM=",
+    "h1:QL1ivYrUSB3zvhgXcRBfQak4HDxvesT2zktM+N6StVo=",
+    "h1:rPbqd7mEyBetQPjyBDBAdwiARulKbh2LwzQp2GSl/AI=",
+    "h1:wraHzpOZSaxgC37HLOt0k5Mstl1iNrol7DvvqkSQ1kc=",
     "zh:0ab31efe760cc86c9eef9e8eb070ae9e15c52c617243bbd9041632d44ea70781",
     "zh:0ee4e906e28f23c598632eeac297ab098d6d6a90629d15516814ab90ad42aec8",
     "zh:3bbb3e9da728b82428c6f18533b5b7c014e8ff1b8d9b2587107c966b985e5bcc",
@@ -66,6 +78,10 @@ provider "registry.terraform.io/hashicorp/time" {
 provider "registry.terraform.io/hashicorp/tls" {
   version = "4.0.5"
   hashes = [
+    "h1:e4LBdJoZJNOQXPWgOAG0UuPBVhCStu98PieNlqJTmeU=",
+    "h1:jb/Rg9inGYp4t8HtBoETESsQJgdmOHoe1bzzg2uNB3w=",
+    "h1:kcw9sNLNFMY2S0HIGOkjlwKtUc8lpqZsQGsC2SG9xEQ=",
+    "h1:yLqz+skP3+EbU3yyvw8JqzflQTKDQGsC9QyZAg+S4dg=",
     "h1:zeG5RmggBZW/8JWIVrdaeSJa0OG62uFX5HY1eE8SjzY=",
     "zh:01cfb11cb74654c003f6d4e32bbef8f5969ee2856394a96d127da4949c65153e",
     "zh:0472ea1574026aa1e8ca82bb6df2c40cd0478e9336b7a8a64e652119a2fa4f32",

--- a/ci/terraform/alerts.tf
+++ b/ci/terraform/alerts.tf
@@ -49,9 +49,9 @@ resource "aws_iam_role_policy_attachment" "parameter_execution" {
 resource "aws_lambda_function" "alerts_lambda" {
   function_name = local.alerts_lambda_name
 
-  s3_bucket         = var.alerts_lambda_zip_file == "" ? var.code_s3_bucket : aws_s3_bucket_object.alerts_source[0].bucket
-  s3_key            = var.alerts_lambda_zip_file == "" ? var.alerts_code_s3_key : aws_s3_bucket_object.alerts_source[0].key
-  s3_object_version = var.alerts_lambda_zip_file == "" ? null : aws_s3_bucket_object.alerts_source[0].version_id
+  s3_bucket         = var.alerts_lambda_zip_file == "" ? var.code_s3_bucket : aws_s3_object.alerts_source[0].bucket
+  s3_key            = var.alerts_lambda_zip_file == "" ? var.alerts_code_s3_key : aws_s3_object.alerts_source[0].key
+  s3_object_version = var.alerts_lambda_zip_file == "" ? null : aws_s3_object.alerts_source[0].version_id
 
 
   role        = aws_iam_role.alerts_execution.arn

--- a/ci/terraform/canary-sign-in-with-ipv.tf
+++ b/ci/terraform/canary-sign-in-with-ipv.tf
@@ -11,9 +11,9 @@ module "canary_sign_in_with_ipv" {
   canary_handler = "canary-sign-in-with-ipv.handler"
   canary_name    = "smoke-ipv"
 
-  canary_source_bucket     = aws_s3_bucket_object.canary_source.bucket
-  canary_source_key        = aws_s3_bucket_object.canary_source.key
-  canary_source_version_id = aws_s3_bucket_object.canary_source.version_id
+  canary_source_bucket     = aws_s3_object.canary_source.bucket
+  canary_source_key        = aws_s3_object.canary_source.key
+  canary_source_version_id = aws_s3_object.canary_source.version_id
 
   sns_topic_pagerduty_p1_alerts_arn = aws_sns_topic.pagerduty_p1_alerts.arn
   sns_topic_pagerduty_p2_alerts_arn = aws_sns_topic.pagerduty_p2_alerts.arn

--- a/ci/terraform/canary-sign-in.tf
+++ b/ci/terraform/canary-sign-in.tf
@@ -11,9 +11,9 @@ module "canary_sign_in" {
   canary_handler = "canary-sign-in.handler"
   canary_name    = "smoke-in"
 
-  canary_source_bucket     = aws_s3_bucket_object.canary_source.bucket
-  canary_source_key        = aws_s3_bucket_object.canary_source.key
-  canary_source_version_id = aws_s3_bucket_object.canary_source.version_id
+  canary_source_bucket     = aws_s3_object.canary_source.bucket
+  canary_source_key        = aws_s3_object.canary_source.key
+  canary_source_version_id = aws_s3_object.canary_source.version_id
 
   sns_topic_pagerduty_p1_alerts_arn = aws_sns_topic.pagerduty_p1_alerts.arn
   sns_topic_pagerduty_p2_alerts_arn = aws_sns_topic.pagerduty_p2_alerts.arn

--- a/ci/terraform/create-account.tf
+++ b/ci/terraform/create-account.tf
@@ -13,9 +13,9 @@ module "canary_create_account" {
   canary_handler = "canary-create-account.handler"
   canary_name    = "smoke-cra"
 
-  canary_source_bucket     = aws_s3_bucket_object.canary_source.bucket
-  canary_source_key        = aws_s3_bucket_object.canary_source.key
-  canary_source_version_id = aws_s3_bucket_object.canary_source.version_id
+  canary_source_bucket     = aws_s3_object.canary_source.bucket
+  canary_source_key        = aws_s3_object.canary_source.key
+  canary_source_version_id = aws_s3_object.canary_source.version_id
 
   sns_topic_pagerduty_p1_alerts_arn = aws_sns_topic.pagerduty_p1_alerts.arn
   sns_topic_pagerduty_p2_alerts_arn = aws_sns_topic.pagerduty_p2_alerts.arn

--- a/ci/terraform/heartbeat.tf
+++ b/ci/terraform/heartbeat.tf
@@ -44,9 +44,9 @@ resource "aws_iam_role_policy_attachment" "cronitor_execution" {
 resource "aws_lambda_function" "cronitor_ping_lambda" {
   function_name = local.cronitor_lambda_name
 
-  s3_bucket         = var.heartbeat_lambda_zip_file == "" ? var.code_s3_bucket : aws_s3_bucket_object.heartbeat_source[0].bucket
-  s3_key            = var.heartbeat_lambda_zip_file == "" ? var.heartbeat_code_s3_key : aws_s3_bucket_object.heartbeat_source[0].key
-  s3_object_version = var.heartbeat_lambda_zip_file == "" ? null : aws_s3_bucket_object.heartbeat_source[0].version_id
+  s3_bucket         = var.heartbeat_lambda_zip_file == "" ? var.code_s3_bucket : aws_s3_object.heartbeat_source[0].bucket
+  s3_key            = var.heartbeat_lambda_zip_file == "" ? var.heartbeat_code_s3_key : aws_s3_object.heartbeat_source[0].key
+  s3_object_version = var.heartbeat_lambda_zip_file == "" ? null : aws_s3_object.heartbeat_source[0].version_id
 
   role        = aws_iam_role.cronitor_execution.arn
   handler     = "heartbeat.handler"

--- a/ci/terraform/modules/canary/heartbeat.tf
+++ b/ci/terraform/modules/canary/heartbeat.tf
@@ -3,9 +3,9 @@ data "aws_lambda_function" "cronitor_ping_lambda" {
 }
 
 resource "aws_cloudwatch_event_rule" "cronitor_event" {
-  count      = var.heartbeat_ping_enabled ? 1 : 0
-  name       = "${local.smoke_tester_name}-cronitor-rule"
-  is_enabled = true
+  count = var.heartbeat_ping_enabled ? 1 : 0
+  name  = "${local.smoke_tester_name}-cronitor-rule"
+  state = "ENABLED"
   event_pattern = jsonencode({
     "source" = [
       "aws.synthetics"

--- a/ci/terraform/s3.tf
+++ b/ci/terraform/s3.tf
@@ -1,17 +1,23 @@
 resource "aws_s3_bucket" "smoketest_artefact_bucket" {
   bucket = "${var.environment}-smoke-test-artefacts"
 
-  acl = "private"
+  tags = local.default_tags
+}
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+resource "aws_s3_bucket_server_side_encryption_configuration" "smoketest_artefact_bucket" {
+  bucket = aws_s3_bucket.smoketest_artefact_bucket.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
+}
 
-  tags = local.default_tags
+resource "aws_s3_bucket_acl" "smoketest_artefact_bucket" {
+  bucket = aws_s3_bucket.smoketest_artefact_bucket.bucket
+
+  acl = "private"
 }
 
 resource "aws_s3_bucket_public_access_block" "smoketest_artefact_private_bucket" {
@@ -25,22 +31,9 @@ resource "aws_s3_bucket_public_access_block" "smoketest_artefact_private_bucket"
 resource "aws_s3_bucket" "smoketest_source_bucket" {
   bucket = "${var.environment}-smoke-test-source"
 
-  acl = "private"
-
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
-
-  versioning {
-    enabled = true
-  }
-
   tags = local.default_tags
 }
+
 
 resource "aws_s3_bucket_public_access_block" "smoketest_source_private_bucket" {
   bucket                  = aws_s3_bucket.smoketest_source_bucket.id
@@ -50,15 +43,40 @@ resource "aws_s3_bucket_public_access_block" "smoketest_source_private_bucket" {
   restrict_public_buckets = true
 }
 
-resource "aws_s3_bucket_object" "canary_source" {
+resource "aws_s3_bucket_server_side_encryption_configuration" "smoketest_source_bucket" {
+  bucket = aws_s3_bucket.smoketest_source_bucket.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_acl" "smoketest_source_bucket" {
+  bucket = aws_s3_bucket.smoketest_source_bucket.bucket
+
+  acl = "private"
+}
+
+resource "aws_s3_bucket_versioning" "smoketest_source_bucket" {
+  bucket = aws_s3_bucket.smoketest_source_bucket.bucket
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_object" "canary_source" {
   bucket = aws_s3_bucket.smoketest_source_bucket.bucket
   key    = "${var.environment}-smoke-test-canary.zip"
 
   source      = var.smoke_test_lambda_zip_file
   source_hash = filemd5(var.smoke_test_lambda_zip_file)
+
 }
 
-resource "aws_s3_bucket_object" "alerts_source" {
+resource "aws_s3_object" "alerts_source" {
   count  = var.alerts_lambda_zip_file == "" ? 0 : 1
   bucket = aws_s3_bucket.smoketest_source_bucket.bucket
   key    = "${var.environment}-alerts-canary.zip"
@@ -67,7 +85,7 @@ resource "aws_s3_bucket_object" "alerts_source" {
   source_hash = filemd5(var.alerts_lambda_zip_file)
 }
 
-resource "aws_s3_bucket_object" "heartbeat_source" {
+resource "aws_s3_object" "heartbeat_source" {
   count  = var.alerts_lambda_zip_file == "" ? 0 : 1
   bucket = aws_s3_bucket.smoketest_source_bucket.bucket
   key    = "${var.environment}-heartbeat-canary.zip"

--- a/ci/terraform/stub-rp-clients.tf
+++ b/ci/terraform/stub-rp-clients.tf
@@ -11,7 +11,7 @@ resource "random_string" "stub_rp_client_id" {
   lower   = true
   upper   = true
   special = false
-  number  = true
+  numeric = true
   length  = 32
 }
 

--- a/scripts/dev_deploy_common.sh
+++ b/scripts/dev_deploy_common.sh
@@ -34,7 +34,7 @@ USAGE
 
 BUILD=0
 TERRAFORM_OPTS="-auto-approve"
-if [[ $# == 0 ]]; then
+if [[ $# == 0 ]] || [[ $* == "-p" ]]; then
     BUILD=1
 fi
 while [[ $# -gt 0 ]]; do

--- a/scripts/terraform-lint.sh
+++ b/scripts/terraform-lint.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+TMPDIR=${TMPDIR:-/tmp}
+TF_DATA_DIR=$(mktemp -d "${TMPDIR}/terraform_lint.XXXXXX")
+trap 'rm -r "${TF_DATA_DIR}"' EXIT
+export TF_DATA_DIR
+
+module_dir="${repo_root}/ci/terraform"
+
+printf "Validating \e[1;93m%s\e[0m...\n" "terraform"
+printf "\e[92m*\e[0m Initializing..."
+terraform -chdir="${module_dir}" init -backend=false &>/dev/null
+printf " done!\n"
+
+terraform -chdir="${module_dir}" validate
+terraform -chdir="${module_dir}" fmt -write=false -diff -recursive >>"${TF_DATA_DIR}"/lint
+if [ -s "${TF_DATA_DIR}"/lint ]; then
+    printf "\e[1;91m%s\e[0m\n" "The following files need to be formatted:"
+    cat "${TF_DATA_DIR}"/lint
+else
+    printf "\e[92m*\e[0m No formatting issues found.\n"
+fi

--- a/scripts/terraform-upgrade.sh
+++ b/scripts/terraform-upgrade.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+TMPDIR=${TMPDIR:-/tmp}
+TF_DATA_DIR=$(mktemp -d "${TMPDIR}/terraform_lint.XXXXXX")
+trap 'rm -r "${TF_DATA_DIR}"' EXIT
+export TF_DATA_DIR
+
+module_dir="${repo_root}/ci/terraform"
+
+printf "Upgrading providers...\n"
+
+printf "\e[92m*\e[0m Initializing..."
+terraform -chdir="${module_dir}" init -backend=false -upgrade &>/dev/null
+printf " done!\n"
+
+printf "\e[92m*\e[0m Locking provider versions:\n"
+terraform -chdir="${module_dir}" providers lock \
+    -platform=windows_amd64 \
+    -platform=linux_amd64 \
+    -platform=linux_arm64 \
+    -platform=darwin_amd64 \
+    -platform=darwin_arm64


### PR DESCRIPTION
## What?

- update provider locks
- Add helper scripts to do common terraform tasks repeatably
- Fix all linting errors in terraform after updating providers

## Why?

- The locks hadn't been fully updated to lock the correct provider versions
- Helper scripts are helpful
- We were using many resources and attributes which have been deprecated, so fix these
