### PR TITLE
AUT-2260 s3 bucket level settings public block

### DIFF
--- a/ci/terraform/s3.tf
+++ b/ci/terraform/s3.tf
@@ -15,10 +15,10 @@ resource "aws_s3_bucket" "smoketest_artefact_bucket" {
 }
 
 resource "aws_s3_bucket_public_access_block" "smoketest_artefact_private_bucket" {
-  bucket = aws_s3_bucket.smoketest_artefact_bucket.id
-  block_public_acls = true
-  ignore_public_acls = true
-  block_public_policy = true
+  bucket                  = aws_s3_bucket.smoketest_artefact_bucket.id
+  block_public_acls       = true
+  ignore_public_acls      = true
+  block_public_policy     = true
   restrict_public_buckets = true
 }
 
@@ -43,10 +43,10 @@ resource "aws_s3_bucket" "smoketest_source_bucket" {
 }
 
 resource "aws_s3_bucket_public_access_block" "smoketest_source_private_bucket" {
-  bucket = aws_s3_bucket.smoketest_source_bucket.id
-  block_public_acls = true
-  ignore_public_acls = true
-  block_public_policy = true
+  bucket                  = aws_s3_bucket.smoketest_source_bucket.id
+  block_public_acls       = true
+  ignore_public_acls      = true
+  block_public_policy     = true
   restrict_public_buckets = true
 }
 

--- a/ci/terraform/s3.tf
+++ b/ci/terraform/s3.tf
@@ -14,7 +14,7 @@ resource "aws_s3_bucket" "smoketest_artefact_bucket" {
   tags = local.default_tags
 }
 
-resource "aws_s3_bucket_public_access_block" "smoketest_artefact_source_bucket" {
+resource "aws_s3_bucket_public_access_block" "smoketest_artefact_private_bucket" {
   bucket = aws_s3_bucket.smoketest_artefact_bucket.id
   block_public_acls = true
   ignore_public_acls = true
@@ -42,7 +42,7 @@ resource "aws_s3_bucket" "smoketest_source_bucket" {
   tags = local.default_tags
 }
 
-resource "aws_s3_bucket_public_access_block" "smoketest_source_bucket" {
+resource "aws_s3_bucket_public_access_block" "smoketest_source_private_bucket" {
   bucket = aws_s3_bucket.smoketest_source_bucket.id
   block_public_acls = true
   ignore_public_acls = true

--- a/ci/terraform/s3.tf
+++ b/ci/terraform/s3.tf
@@ -14,6 +14,14 @@ resource "aws_s3_bucket" "smoketest_artefact_bucket" {
   tags = local.default_tags
 }
 
+resource "aws_s3_bucket_public_access_block" "smoketest_artefact_source_bucket" {
+  bucket = aws_s3_bucket.smoketest_artefact_bucket.id
+  block_public_acls = true
+  ignore_public_acls = true
+  block_public_policy = true
+  restrict_public_buckets = true
+}
+
 resource "aws_s3_bucket" "smoketest_source_bucket" {
   bucket = "${var.environment}-smoke-test-source"
 
@@ -32,6 +40,14 @@ resource "aws_s3_bucket" "smoketest_source_bucket" {
   }
 
   tags = local.default_tags
+}
+
+resource "aws_s3_bucket_public_access_block" "smoketest_source_bucket" {
+  bucket = aws_s3_bucket.smoketest_source_bucket.id
+  block_public_acls = true
+  ignore_public_acls = true
+  block_public_policy = true
+  restrict_public_buckets = true
 }
 
 resource "aws_s3_bucket_object" "canary_source" {


### PR DESCRIPTION
## What?

Added Public block to S3 bucket

## Why?

Old bucket which were created before the public Block setting was enabled at account setting are getting flagged in CPC finding as Public block missing


