### PR TITLE
AUT-2485: Improve Dev deployment scripts

### DIFF
--- a/deploy-sandpit.sh
+++ b/deploy-sandpit.sh
@@ -1,70 +1,10 @@
 #!/usr/bin/env bash
 
 set -eu
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
-function runTerraform() {
-  echo "Running ${1} Terraform..."
-  pushd "${DIR}/ci/terraform/${1}" > /dev/null
-  rm -rf .terraform/
-  terraform init -backend-config=sandpit.hcl
-  terraform apply -var-file sandpit.tfvars -var-file sandpit-stub-clients.tfvars ${2}
-  popd > /dev/null
-}
+export DEPLOY_ENV="sandpit"
+export AWS_PROFILE="gds-di-development-admin"
 
-function usage() {
-  cat <<USAGE
-  A script to deploy the GOV.UK Sign in smoke tests to the sandpit environment.
-  Requires a GDS CLI, AWS CLI and jq installed and configured.
-
-  Usage:
-    $0 [-b|--build] [-c|--clean] [-s|--shared] [-o|--oidc] [-a|--account-management] [--audit] [--destroy] [-p|--prompt]
-
-  Options:
-    -b, --build               run yarn install and build tasks (default)
-    --destroy                 run all terraform with the -destroy flag (destroys all managed resources)
-    -p, --prompt              will prompt for plan review before applying any terraform
-
-    If no options specified the default actions above will be carried out without prompting.
-USAGE
-}
-
-BUILD=0
-TERRAFORM_OPTS="-auto-approve"
-if [[ $# == 0 ]]; then
-  BUILD=1
-fi
-while [[ $# -gt 0 ]]; do
-  case $1 in
-    -b|--build)
-      BUILD=1
-      ;;
-    --destroy)
-      TERRAFORM_OPTS="-destroy"
-      ;;
-    -p|--prompt)
-      TERRAFORM_OPTS=""
-      ;;
-    *)
-      usage
-      exit 1
-      ;;
-  esac
-  shift
-done
-
-if [[ $BUILD == "1" ]]; then
-  echo "Building deployment artefacts ... "
-  pushd "${DIR}" > /dev/null
-  yarn clean && yarn install --production && yarn build
-  mkdir -p ../release-artefacts/
-  cp dist/*.zip ../release-artefacts/
-  popd > /dev/null
-  echo "done!"
-fi
-
-echo -n "Getting AWS credentials ... "
-eval $(gds aws digital-identity-dev -e)
-echo "done!"
-
-runTerraform "." "${TERRAFORM_OPTS}"
+# shellcheck source=scripts/dev_deploy_common.sh
+source "${DIR}/scripts/dev_deploy_common.sh"

--- a/scripts/dev_deploy_common.sh
+++ b/scripts/dev_deploy_common.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] || {
+    echo "Error: Script must be sourced, not executed"
+    exit 1
+}
+
+function runTerraform() {
+    echo "Running ${1} Terraform..."
+    pushd "${DIR}/ci/terraform/${1}" >/dev/null
+    rm -rf .terraform/
+    terraform init -backend-config=sandpit.hcl
+    terraform apply -var-file sandpit.tfvars -var-file sandpit-stub-clients.tfvars ${2}
+    popd >/dev/null
+}
+
+function usage() {
+    cat <<USAGE
+  A script to deploy the GOV.UK Sign in smoke tests to the sandpit environment.
+  Requires a GDS CLI, AWS CLI and jq installed and configured.
+
+  Usage:
+    $0 [-b|--build] [-c|--clean] [-s|--shared] [-o|--oidc] [-a|--account-management] [--audit] [--destroy] [-p|--prompt]
+
+  Options:
+    -b, --build               run yarn install and build tasks (default)
+    --destroy                 run all terraform with the -destroy flag (destroys all managed resources)
+    -p, --prompt              will prompt for plan review before applying any terraform
+
+    If no options specified the default actions above will be carried out without prompting.
+USAGE
+}
+
+BUILD=0
+TERRAFORM_OPTS="-auto-approve"
+if [[ $# == 0 ]]; then
+    BUILD=1
+fi
+while [[ $# -gt 0 ]]; do
+    case $1 in
+    -b | --build)
+        BUILD=1
+        ;;
+    --destroy)
+        TERRAFORM_OPTS="-destroy"
+        ;;
+    -p | --prompt)
+        TERRAFORM_OPTS=""
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+    shift
+done
+
+if [[ $BUILD == "1" ]]; then
+    echo "Building deployment artefacts ... "
+    pushd "${DIR}" >/dev/null
+    yarn clean && yarn install --production && yarn build
+    mkdir -p ../release-artefacts/
+    cp dist/*.zip ../release-artefacts/
+    popd >/dev/null
+    echo "done!"
+fi
+
+# shellcheck source=./scripts/export_aws_creds.sh
+source "${DIR}/scripts/export_aws_creds.sh"
+
+runTerraform "." "${TERRAFORM_OPTS}"

--- a/scripts/export_aws_creds.sh
+++ b/scripts/export_aws_creds.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] || {
+  echo "Error: Script must be sourced, not executed"
+  exit 1
+}
+
+if [[ -n "${AWS_ACCESS_KEY_ID:-}" && -n "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+  echo "Using AWS credentials from existing environment variables"
+else
+  echo "Exporting credentials from AWS CLI profile ${AWS_PROFILE}"
+
+  # Test if the AWS CLI is configured with the correct profile
+  if ! sso_session="$(aws configure get sso_session --profile "${AWS_PROFILE}")"; then
+    echo "AWS CLI profile ${AWS_PROFILE} is not configured."
+    echo "Please visit https://govukverify.atlassian.net/wiki/x/IgFm5 for instructions."
+    exit 1
+  fi
+  if ! aws sts get-caller-identity --profile "${AWS_PROFILE}" >/dev/null; then
+    aws sso login --sso-session "${sso_session}"
+  fi
+  if ! aws_export="$(aws configure export-credentials --profile "${AWS_PROFILE}" --format env 2>/dev/null)"; then
+    echo "Failed to export AWS credentials from AWS CLI profile ${AWS_PROFILE}."
+    echo "Please visit https://govukverify.atlassian.net/wiki/x/IgFm5 for instructions."
+    exit 1
+  fi
+  eval "${aws_export}"
+fi
+
+configured_region="$(aws configure get region --profile "${AWS_PROFILE}" 2>/dev/null)"
+if [[ -n "${configured_region:-}" ]]; then
+  export AWS_REGION="${configured_region}"
+fi


### PR DESCRIPTION
## What?

- Use well-known AWS profile names
- Pull out common code from deploy-sandpit.sh into a common script
- Pull out AWS credential export into a separate script

## Why?

Local profile names were different for each person's laptop. This standardises them.

Also, it makes the deploy scripts easier to maintain.

## How to review

- use python script implemented in govuk-one-login/authentication-api#4042 to create the correct AWS accounts
- deploy something to sandpit - check there are no errors
