### PR TITLE
BAU: Use 6.2 instead

### DIFF
--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -218,5 +218,5 @@ variable "smoke_test_cron_expression" {
 
 variable "runtime_version" {
   type    = string
-  default = "syn-nodejs-puppeteer-7.0"
+  default = "syn-nodejs-puppeteer-6.2"
 }


### PR DESCRIPTION
Having issues with 7.0, let's use 6.2 instead
