### PR TITLE
BAU fixing read-secret script jq is outdated

### DIFF
--- a/ci/terraform/read_secrets.sh
+++ b/ci/terraform/read_secrets.sh
@@ -1,18 +1,31 @@
 #!/bin/bash
-ENVIRONMENT=$1
+set -euo pipefail
+
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] || {
+  echo "Error: Script must be sourced, not executed"
+  exit 1
+}
+
+ENVIRONMENT="${1}"
 
 if [ "$ENVIRONMENT" = "dev" ]; then
-	ENVIRONMENT="build";
+  ENVIRONMENT="build"
 fi
 
-secrets=$(aws secretsmanager list-secrets --filter Key="name",Values="/deploy/$ENVIRONMENT/" --region eu-west-2 | jq -c '.SecretList[]')
+secrets="$(
+  aws secretsmanager list-secrets \
+    --filter "Key=\"name\",Values=\"/deploy/${ENVIRONMENT}/\"" --region eu-west-2 |
+    jq -r '.SecretList[]|[.ARN,(.Name|split("/")|last)]|@tsv'
+)"
 
-for i in $secrets; do
-  arn=$(echo $i | jq -r '.ARN')
-  name=$(echo $i | jq -r '.Name | split("/") | last')
-  value=$(aws secretsmanager get-secret-value --secret-id $arn | jq -r '.SecretString')
-  VAR=(TF_VAR_$name=$value)
-  export $VAR
-done
+if [ -z "${secrets}" ]; then
+  printf '!! ERROR: No secrets found for environment %s. Exiting.\n' "${ENVIRONMENT}" >&2
+  exit 1
+fi
+
+while IFS=$'\t' read -r arn name; do
+  value=$(aws secretsmanager get-secret-value --secret-id "${arn}" | jq -r '.SecretString')
+  export "TF_VAR_${name}"="${value}"
+done <<<"${secrets}"
 
 export TF_VAR_hashed_password=`echo -n "${TF_VAR_smoke_tester_password}" | argon2 $(openssl rand -hex 32) -e -id -v 13 -k 15360 -t 2 -p 1`


### PR DESCRIPTION
## What?

The read_secrets.sh is failing to read the secret

## Why?

read_secrets.sh script is failing to read secret dues to outdated jq search

parse error: Invalid numeric literal at line 2, column 0

