### PR TITLE
canary-Failure-and-log-retention

### DIFF
--- a/ci/terraform/canary-sign-in-with-ipv.tf
+++ b/ci/terraform/canary-sign-in-with-ipv.tf
@@ -35,7 +35,7 @@ module "canary_sign_in_with_ipv" {
   smoke_test_cron_expression = var.smoke_test_cron_expression
 
   cloudwatch_key_arn       = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
-  cloudwatch_log_retention = 1
+  cloudwatch_log_retention = 7
   logging_endpoint_arns    = var.logging_endpoint_arns
   runtime_version          = var.runtime_version
   depends_on = [

--- a/ci/terraform/canary-sign-in.tf
+++ b/ci/terraform/canary-sign-in.tf
@@ -35,7 +35,7 @@ module "canary_sign_in" {
   smoke_test_cron_expression = var.smoke_test_cron_expression
 
   cloudwatch_key_arn       = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
-  cloudwatch_log_retention = 1
+  cloudwatch_log_retention = 7
   logging_endpoint_arns    = var.logging_endpoint_arns
   runtime_version          = var.runtime_version
 

--- a/ci/terraform/create-account.tf
+++ b/ci/terraform/create-account.tf
@@ -41,7 +41,7 @@ module "canary_create_account" {
   start_canary               = false
 
   cloudwatch_key_arn       = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
-  cloudwatch_log_retention = 1
+  cloudwatch_log_retention = 7
   logging_endpoint_arns    = var.logging_endpoint_arns
   runtime_version          = var.runtime_version
   depends_on = [

--- a/ci/terraform/modules/canary/canary.tf
+++ b/ci/terraform/modules/canary/canary.tf
@@ -13,7 +13,7 @@ resource "aws_synthetics_canary" "smoke_tester_canary" {
   s3_version = var.canary_source_version_id
 
   success_retention_period = 1
-  failure_retention_period = 7
+  failure_retention_period = 14
 
   run_config {
     active_tracing     = false


### PR DESCRIPTION
## What?
Increasing the failure retention from 7 days to 14 days also increasing the canary cloud watch log retention to 7 days 

