### PR TITLE
BAU: Downgrade canary runtime to 6.2

### DIFF
--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -218,5 +218,5 @@ variable "smoke_test_cron_expression" {
 
 variable "runtime_version" {
   type    = string
-  default = "syn-nodejs-puppeteer-7.0"
+  default = "syn-nodejs-puppeteer-6.2"
 }


### PR DESCRIPTION

## What?

Downgrade canary runtime to 6.2.

## Why?

Seeing smoketest errors which appear to have become more frequent recently. Downgrading just to rule the runtime version out as a cause of the issues.

