### PR TITLE
AUT-1506: Turn on create account canaries in integration and production

### DIFF
--- a/ci/terraform/create-account.tf
+++ b/ci/terraform/create-account.tf
@@ -38,7 +38,6 @@ module "canary_create_account" {
 
   # the test will run Mon-Fri, between 0800-1700 (UTC) every 3 minutes
   smoke_test_cron_expression = "0/03 08-17 ? * MON-FRI *"
-  start_canary               = false
 
   cloudwatch_key_arn       = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention = 7


### PR DESCRIPTION
These had been disabled since the switch from concouse to aws code pipelines, since a variable had not been migrated over, and the canaries were noisily failing. This has now been fixed, and we've trialled manually turning these alarms on in both environments, with successful runs.

The alarms will be turned on separately once we've seen a day or so of successful runs.

## Related PRs

Fixes in the api: [integration](https://github.com/govuk-one-login/authentication-api/pull/4201) and [production](https://github.com/govuk-one-login/authentication-api/pull/4208)


