### PR TITLE
AUT-1506: Turn on alarms for create account smoke tests

### DIFF
--- a/ci/terraform/integration-overrides.tfvars
+++ b/ci/terraform/integration-overrides.tfvars
@@ -5,7 +5,7 @@ logging_endpoint_arns = [
 ]
 
 create_account_metric_alarm_enabled   = true
-create_account_heartbeat_ping_enabled = false
+create_account_heartbeat_ping_enabled = true
 
 ipv_sign_in_metric_alarm_enabled   = true
 ipv_sign_in_heartbeat_ping_enabled = false

--- a/ci/terraform/production-overrides.tfvars
+++ b/ci/terraform/production-overrides.tfvars
@@ -4,8 +4,8 @@ logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
 
-create_account_metric_alarm_enabled   = false
-create_account_heartbeat_ping_enabled = false
+create_account_metric_alarm_enabled   = true
+create_account_heartbeat_ping_enabled = true
 
 ipv_sign_in_metric_alarm_enabled   = true
 ipv_sign_in_heartbeat_ping_enabled = false


### PR DESCRIPTION
These have now been re-enabled after the issue with them was fixed. We can therefore turn back on the alerting for them.

## Related PRs

We re-enabled the smoke tests [here](https://github.com/govuk-one-login/authentication-smoke-tests/pull/400)
