### PR TITLE
AUT-1506: Update create account smoke tests to run 24/7 in production

### DIFF
--- a/ci/terraform/create-account.tf
+++ b/ci/terraform/create-account.tf
@@ -36,8 +36,7 @@ module "canary_create_account" {
   client_private_key          = tls_private_key.stub_rp_client_private_key[0].private_key_pem
   issuer_base_url             = var.issuer_base_url
 
-  # the test will run Mon-Fri, between 0800-1700 (UTC) every 3 minutes
-  smoke_test_cron_expression = "0/03 08-17 ? * MON-FRI *"
+  smoke_test_cron_expression = var.smoke_test_cron_expression
 
   cloudwatch_key_arn       = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention = 7


### PR DESCRIPTION
The other smoke tests have previously been updated to do the same (although they still only run within office hours in the integration environment). Since we have now fully fixed and re-enabled the create account tests (which had previously been broken since the migration from concourse to aws pipelines), we should also run these tests on the same schedule.

## What?

Please include a summary of the change.

## Why?

Please include reason for the change and any other relevant context.

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.
