### PR TITLE
AUT-2688: Upgrade aws dependency to 3.x

### DIFF
--- a/alerts/alerts.js
+++ b/alerts/alerts.js
@@ -1,4 +1,3 @@
-const axios = require("axios");
 const { getParameter } = require("./aws");
 
 const formatMessage = (snsMessage, colorCode, snsMessageFooter) => {
@@ -80,18 +79,19 @@ const handler = async function (event, context) {
 
   var config = {
     method: "post",
-    url: slackHookUrl,
     headers: {
       "Content-Type": "application/json",
     },
-    data: JSON.stringify(
+    body: JSON.stringify(
       formatMessage(snsMessage, colorCode, snsMessageFooter)
     ),
   };
   console.log("Sending alert to slack");
   try {
-    const response = await axios(config);
-    console.log(JSON.stringify(response.data));
+    // eslint-disable-next-line no-undef
+    const response = await fetch(slackHookUrl, config);
+    const message = await response.text();
+    console.log(message);
   } catch (error) {
     console.log(error);
   }

--- a/alerts/aws.js
+++ b/alerts/aws.js
@@ -1,12 +1,12 @@
-const AWS = require("aws-sdk"); // eslint-disable-line node/no-unpublished-require
+const { SSM } = require("@aws-sdk/client-ssm");
 
-const SSM = new AWS.SSM();
+const client = new SSM();
 
 const getParameter = async (parameterName) => {
-  const result = await SSM.getParameter({
+  const result = await client.getParameter({
     Name: `${parameterName}`,
     WithDecryption: true,
-  }).promise();
+  });
 
   return result.Parameter.Value;
 };

--- a/alerts/package.json
+++ b/alerts/package.json
@@ -4,10 +4,8 @@
   "main": "alerts.js",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.26.1"
-  },
-  "devDependencies": {
-    "aws-sdk": "^2.1099.0"
+    "@aws-sdk/client-ssm": "3.354.0",
+    "@aws-sdk/client-sts": "3.354.0"
   },
   "scripts": {
     "build": "mkdir -p ../dist && zip -r ../dist/alerts.zip ."


### PR DESCRIPTION
The runtime of the alerts lambda was recently upgraded to node 18, which requires us to use version 3.x of the aws sdk. There were also some differences introduced as to how to import.

This replicates what has already been done in the slack-src directory here.

This is similar to the following change for the slack lambda when it was in a different repo: https://github.com/govuk-one-login/monitoring-utils/commit/9b99dc881e079711817ef760acaba4b1a0e16ebf 
