### PR TITLE
ATO-563: subscribe alerts lambda to cloudwatch alerts topic

### DIFF
--- a/ci/terraform/alerts.tf
+++ b/ci/terraform/alerts.tf
@@ -105,3 +105,24 @@ resource "aws_lambda_permission" "slack_alerts_with_sns" {
 data "aws_sns_topic" "slack_alerts" {
   name = "${var.environment}-slack-alerts"
 }
+
+resource "aws_sns_topic_subscription" "cloudfront_alerts" {
+  provider = aws.cloudfront
+
+  topic_arn = data.aws_sns_topic.cloudfront_alerts
+  protocol  = "lambda"
+  endpoint  = aws_lambda_function.alerts_lambda.arn
+}
+
+resource "aws_lambda_permission" "cloudfront_alerts" {
+  statement_id  = "AllowExecutionFromCloudfrontAlertsSNSTopic"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.alerts_lambda.function_name
+  principal     = "sns.amazonaws.com"
+  source_arn    = data.aws_sns_topic.cloudfront_alerts.arn
+}
+
+data "aws_sns_topic" "cloudfront_alerts" {
+  provider = aws.cloudfront
+  name     = "${var.environment}-oidc-cloudfront-alerts"
+}

--- a/ci/terraform/site.tf
+++ b/ci/terraform/site.tf
@@ -24,6 +24,16 @@ provider "aws" {
   }
 }
 
+provider "aws" {
+  alias = "cloudfront"
+
+  region = "us-east-1"
+
+  assume_role {
+    role_arn = var.deployer_role_arn
+  }
+}
+
 provider "time" {}
 
 locals {


### PR DESCRIPTION
## What?
As part of the cloudfront work, there will be new alerts in us-east-1. This subscribes to a new SNS topic in that region and forwards the alerts to slack.

## Related PRs
Must be merged after https://github.com/govuk-one-login/authentication-api/pull/4310