### PR TITLE
AUT-2686: Temporarily increase p1 alerting threshold

### DIFF
--- a/ci/terraform/modules/canary/alarm.tf
+++ b/ci/terraform/modules/canary/alarm.tf
@@ -8,7 +8,7 @@ resource "aws_cloudwatch_metric_alarm" "smoke_tester_metric_alarm_p1" {
   namespace           = "CloudWatchSynthetics"
   period              = "600"
   statistic           = "Sum"
-  threshold           = "2"
+  threshold           = "3"
   treat_missing_data  = "notBreaching"
 
   dimensions = {


### PR DESCRIPTION
We have some flakiness with smoke tests. Bumping the alerting threshold to 3 failures within the time period means that we don't send pagerduty alerts for known problems to 2nd line while we deal with the underlying root cause.

This should be reverted when the underlying problem is fixed.