### PR TITLE
Revert "BAU: Bump express-openid-connect from 2.16.0 to 2.17.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "crypto": "^1.0.1",
     "express": "^4.19.2",
-    "express-openid-connect": "^2.17.1"
+    "express-openid-connect": "^2.16.0"
   },
   "devDependencies": {
     "aws-sdk": "^2.1561.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -627,10 +627,10 @@ events@1.1.1:
   resolved "https://registry.npmjs.org/events/-/events-1.1.1.tgz"
   integrity sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==
 
-express-openid-connect@^2.17.1:
-  version "2.17.1"
-  resolved "https://registry.yarnpkg.com/express-openid-connect/-/express-openid-connect-2.17.1.tgz#b7c6169d5b694c7ab791671dd3af3f8346611cc6"
-  integrity sha512-5pVK6PNV09x6UN29R9Mer0XF3hwQq2HxiFsjZvLuIQ9ezeTUGbqrefzBOpzciz1S/1WWVaVPDIcj4EBpD8WB3Q==
+express-openid-connect@^2.16.0:
+  version "2.16.0"
+  resolved "https://registry.npmjs.org/express-openid-connect/-/express-openid-connect-2.16.0.tgz"
+  integrity sha512-BSfILqWEiE285PycycXb/HLYXtsnS/AnVRHAmvtJ5h1TZrhN6ddR6rhAI2svZlKStCAubc+W346pEXy1hIRfhQ==
   dependencies:
     base64url "^3.0.1"
     clone "^2.1.2"


### PR DESCRIPTION
Reverts govuk-one-login/authentication-smoke-tests#248