### PR TITLE
Revert "AUT-2686: Temporarily increase p1 alerting threshold"

### DIFF
--- a/ci/terraform/modules/canary/alarm.tf
+++ b/ci/terraform/modules/canary/alarm.tf
@@ -8,7 +8,7 @@ resource "aws_cloudwatch_metric_alarm" "smoke_tester_metric_alarm_p1" {
   namespace           = "CloudWatchSynthetics"
   period              = "600"
   statistic           = "Sum"
-  threshold           = "3"
+  threshold           = "2"
   treat_missing_data  = "notBreaching"
 
   dimensions = {


### PR DESCRIPTION
This reverts commit d8d3e81bb3fa53a1538fc3d509f8d7b8c90b6593.

We previously increased the threshold at which smoke test failures would alert on a P1. This was because of a known flakey issue that has since been fixed in the frontend[1]. Sometimes these flakey issues would appear close enough together to trigger the alert.

These errors have not appeared again (there are still occassional unrelated environment errors but these do not happen often enough to cause issues) so we can restore the original thresholds.

[1]: https://github.com/govuk-one-login/authentication-frontend/pull/1575
