### PR TITLE
BAU: Move integration alerts to different slack channel

### DIFF
--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -220,3 +220,9 @@ variable "runtime_version" {
   type    = string
   default = "syn-nodejs-puppeteer-6.2"
 }
+
+variable "slack_channel_id" {
+  type        = string
+  default     = ""
+  description = "Slack channel ID for alerts to be sent to from alerts lambda. Populated from Secrets Manager at deploy time"
+}


### PR DESCRIPTION
The alerts from the integration environment are causing a lot of noise in the 2nd line channel, and are on the team to investigate, not the support rota. This moves the slack notifications to a team channel.
