### PR TITLE
AUT-2729: Verify page titles instead of body

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,13 +1,13 @@
 const { getParameter } = require("./aws");
 
-const validateText = async (expectedText, page) => {
-  await page.evaluate((expectedText) => {
+const validateTitle = async (expectedTitle, page) => {
+  await page.evaluate((expectedTitle) => {
     // eslint-disable-next-line no-undef
-    const bodyText = document.body.innerText;
-    if (!bodyText.includes(expectedText)) {
-      throw new Error(`Page does not contain text '${expectedText}'`);
+    const title = document.title;
+    if (!title.includes(expectedTitle)) {
+      throw new Error(`Page title does not contain text '${expectedTitle}'`);
     }
-  }, expectedText);
+  }, expectedTitle);
 };
 
 const validateNoText = async (notExpectedText, page) => {
@@ -41,7 +41,7 @@ const authenticateWithBasicAuth = async (page) => {
 };
 
 module.exports = {
-  validateText,
+  validateTitle,
   validateNoText,
   validateUrlContains,
   setStandardViewportSize,

--- a/src/steps.js
+++ b/src/steps.js
@@ -3,19 +3,19 @@ const synthetics = require("Synthetics");
 const { getOTPCode } = require("./aws");
 const { selectors } = require("./vars");
 const {
-  validateText,
   validateNoText,
   validateUrlContains,
+  validateTitle,
 } = require("./helpers");
 
-const launchClient = async (page, clientBaseUrl, textToValidate) => {
+const launchClient = async (page, clientBaseUrl, titleToValidate) => {
   await synthetics.executeStep("Launch Client", async () => {
     await page.goto(clientBaseUrl, {
       waitUntil: "domcontentloaded",
       timeout: 60000,
     });
 
-    await validateText(textToValidate, page);
+    await validateTitle(titleToValidate, page);
   });
 };
 


### PR DESCRIPTION
The purpose of the smoke tests is to verify if a page loads correctly, not to validate the content in its body. Thus, it is correct to validate the page title (as it correctly reflects the status of the page) instead of the body, as the body is subject to change. This was necessary as a smoke test failure came as a result of a content body change.

## What?

Validate title, not body content, in smoke tests. 

## Why?

Validating body content (that is subject to change and validation errors) causes problems. 
