### PR TITLE
BAU: Bump node version used in pre-merge-checks

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 14.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
       - name: Install dependencies
         run: yarn install
       - name: Check formatting


### PR DESCRIPTION
## What?

Bumped node version used in pre-merge-checks from 14 to 18

