### PR TITLE
AUT-3047: Improve create account smoke tests

### DIFF
--- a/src/canary-create-account.js
+++ b/src/canary-create-account.js
@@ -135,10 +135,8 @@ const basicCustomEntryPoint = async () => {
 
   await synthetics.executeStep("Click create account", async () => {
     await page.waitForSelector("#main-content #create-account-link");
-    await page.click("#main-content #create-account-link");
+    Promise.all([navigationPromise, page.click("#main-content #create-account-link")])
   });
-
-  await navigationPromise;
 
   await synthetics.executeStep("Enter email create", async () => {
     await page.waitForSelector(selectors.emailInput);
@@ -147,10 +145,8 @@ const basicCustomEntryPoint = async () => {
 
   await synthetics.executeStep("Click continue", async () => {
     await page.waitForSelector(selectors.submitFormButton);
-    await page.click(selectors.submitFormButton);
+    Promise.all([navigationPromise, page.click(selectors.submitFormButton)])
   });
-
-  await navigationPromise;
 
   await synthetics.executeStep("Check your email", async () => {
     await page.waitForSelector(selectors.otpCodeInput);
@@ -160,10 +156,8 @@ const basicCustomEntryPoint = async () => {
 
   await synthetics.executeStep("Click continue", async () => {
     await page.waitForSelector(selectors.submitFormButton);
-    await page.click(selectors.submitFormButton);
+    Promise.all([navigationPromise, page.click(selectors.submitFormButton)])
   });
-
-  await navigationPromise;
 
   await synthetics.executeStep("Create password", async () => {
     await page.waitForSelector(selectors.passwordInput);
@@ -173,10 +167,8 @@ const basicCustomEntryPoint = async () => {
 
   await synthetics.executeStep("Click continue", async () => {
     await page.waitForSelector(selectors.submitFormButton);
-    await page.click(selectors.submitFormButton);
+    Promise.all([navigationPromise, page.click(selectors.submitFormButton)])
   });
-
-  await navigationPromise;
 
   await synthetics.executeStep("Choose how to get security codes", async () => {
     await page.waitForSelector(".govuk-grid-row #mfaOptions");
@@ -185,10 +177,8 @@ const basicCustomEntryPoint = async () => {
 
   await synthetics.executeStep("Click continue", async () => {
     await page.waitForSelector(selectors.submitFormButton);
-    await page.click(selectors.submitFormButton);
+    Promise.all([navigationPromise, page.click(selectors.submitFormButton)])
   });
-
-  await navigationPromise;
 
   await synthetics.executeStep("Enter your mobile phone number", async () => {
     await page.waitForSelector(".govuk-grid-row #phoneNumber");
@@ -197,7 +187,7 @@ const basicCustomEntryPoint = async () => {
 
   await synthetics.executeStep("Click continue", async () => {
     await page.waitForSelector(selectors.submitFormButton);
-    await page.click(selectors.submitFormButton);
+    Promise.all([navigationPromise, page.click(selectors.submitFormButton)])
   });
 
   await synthetics.executeStep("Enter OTP code", async () => {
@@ -210,10 +200,8 @@ const basicCustomEntryPoint = async () => {
 
   await synthetics.executeStep("Click continue", async () => {
     await page.waitForSelector(selectors.submitFormButton);
-    await page.click(selectors.submitFormButton);
+    Promise.all([navigationPromise, page.click(selectors.submitFormButton)])
   });
-
-  await navigationPromise;
 
   await synthetics.executeStep("Account created confirmation", async () => {
     (await page.url()).endsWith("/account-created");
@@ -223,7 +211,7 @@ const basicCustomEntryPoint = async () => {
     await page.waitForSelector(selectors.submitFormButton);
     await Promise.all([
       page.click(selectors.submitFormButton),
-      page.waitForNavigation(),
+      navigationPromise,
     ]);
   });
 

--- a/src/steps.js
+++ b/src/steps.js
@@ -85,23 +85,6 @@ const submitOtpCode = async (page) => {
   });
 };
 
-const ipvHandOff = async (page) => {
-  await synthetics.executeStep("IPV hand-off", async () => {
-    const pageTitleForConsole = await page.title();
-
-    log.info(pageTitleForConsole);
-
-    const hasReachedIPV =
-      (await page.title()) ===
-      "Tell us if you have one of the following types of photo ID – GOV.UK One Login";
-
-    if (!hasReachedIPV) {
-      throw new Error(`Failed at IPV Hand-off step`);
-    }
-  });
-};
-
-// Note only used by IPV canary
 const microclientUserInfo = async (page, email) => {
   await synthetics.executeStep("Microclient user info", async () => {
     await page.content();
@@ -119,6 +102,114 @@ const microclientUserInfo = async (page, email) => {
   });
 };
 
+// Note only used by IPV canary
+const ipvHandOff = async (page) => {
+  await synthetics.executeStep("IPV hand-off", async () => {
+    const pageTitleForConsole = await page.title();
+
+    log.info(pageTitleForConsole);
+
+    const hasReachedIPV =
+      (await page.title()) ===
+      "Tell us if you have one of the following types of photo ID – GOV.UK One Login";
+
+    if (!hasReachedIPV) {
+      throw new Error(`Failed at IPV Hand-off step`);
+    }
+  });
+};
+
+// Steps only used by Create Account canary
+
+const clickCreateAccount = async (page) => {
+  await synthetics.executeStep("Click create account", async () => {
+    await page.waitForSelector("#main-content #create-account-link");
+    await waitForNavigationAndClick(page, selectors.createAccountButton);
+    await validateUrlContains("enter-email-create", page);
+  });
+};
+
+const submitEmailCreate = async (page) => {
+  await synthetics.executeStep("Click continue", async () => {
+    await page.waitForSelector(selectors.submitFormButton);
+    await waitForNavigationAndClick(page, selectors.submitFormButton);
+  });
+  await validateUrlContains("check-your-email", page);
+};
+
+const createPassword = async (page, password) => {
+  await synthetics.executeStep("Create password", async () => {
+    await page.waitForSelector(selectors.passwordInput);
+    await page.type(selectors.passwordInput, password);
+    await page.type(selectors.confirmPasswordInput, password);
+  });
+};
+
+const submitCreatePassword = async (page) => {
+  await synthetics.executeStep("Click continue", async () => {
+    await page.waitForSelector(selectors.submitFormButton);
+    await waitForNavigationAndClick(page, selectors.submitFormButton);
+    await validateUrlContains("get-security-codes", page);
+  });
+};
+
+const chooseSMSForSecurityCodes = async (page) => {
+  await synthetics.executeStep("Choose how to get security codes", async () => {
+    await page.waitForSelector(selectors.smsMfaRadio);
+    await page.click(selectors.smsMfaRadio);
+  });
+};
+
+const submitSecurityCodesChoice = async (page) => {
+  await synthetics.executeStep("Click continue", async () => {
+    await page.waitForSelector(selectors.submitFormButton);
+    await waitForNavigationAndClick(page, selectors.submitFormButton);
+    await validateUrlContains("enter-phone-number", page);
+  });
+};
+
+const enterPhoneNumber = async (page, phoneNumber) => {
+  await synthetics.executeStep("Enter your mobile phone number", async () => {
+    await page.waitForSelector(selectors.phoneNumberInput);
+    await page.type(selectors.phoneNumberInput, phoneNumber);
+  });
+};
+
+const submitPhoneNumber = async (page) => {
+  await synthetics.executeStep("Click continue", async () => {
+    await waitForNavigationAndClick(page, selectors.submitFormButton);
+    await validateUrlContains("check-your-phone", page);
+  });
+};
+
+const submitPhoneOTP = async (page) => {
+  await synthetics.executeStep("Click continue", async () => {
+    await page.waitForSelector(selectors.submitFormButton);
+    await waitForNavigationAndClick(page, selectors.submitFormButton);
+    await validateUrlContains("account-created", page);
+  });
+};
+
+// Helper steps
+
+const standardClickContinue = async (page) => {
+  await synthetics.executeStep("Click continue", async () => {
+    await page.waitForSelector(selectors.submitFormButton);
+    await waitForNavigationAndClick(page, selectors.submitFormButton);
+  });
+};
+
+// In step helper functions
+
+function waitForNavigationAndClick(page, selector) {
+  return Promise.all([
+    page.waitForNavigation({
+      waitUntil: "networkidle0",
+    }),
+    page.click(selector),
+  ]);
+}
+
 module.exports = {
   launchClient,
   clickSignIn,
@@ -130,4 +221,14 @@ module.exports = {
   submitOtpCode,
   ipvHandOff,
   microclientUserInfo,
+  clickCreateAccount,
+  submitEmailCreate,
+  createPassword,
+  submitCreatePassword,
+  chooseSMSForSecurityCodes,
+  submitSecurityCodesChoice,
+  enterPhoneNumber,
+  submitPhoneNumber,
+  submitPhoneOTP,
+  standardClickContinue,
 };

--- a/src/vars.js
+++ b/src/vars.js
@@ -1,10 +1,14 @@
 const selectors = {
   signInButton: "#main-content #sign-in-button",
+  createAccountButton: "#main-content #create-account-link",
   submitFormButton:
     "#main-content > .govuk-grid-row > .govuk-grid-column-two-thirds > form > .govuk-button",
   passwordInput: ".govuk-grid-row #password",
+  confirmPasswordInput: ".govuk-grid-row #confirm-password",
   emailInput: ".govuk-grid-row #email",
   otpCodeInput: ".govuk-grid-row #code",
+  smsMfaRadio: ".govuk-grid-row #mfaOptions",
+  phoneNumberInput: ".govuk-grid-row #phoneNumber",
 };
 
 module.exports = { selectors };


### PR DESCRIPTION
## What?

- This fixes the potential race condition between page.waitForNavigation() and page.click() by placing both methods inside a Promise.all() block.
- Adds extra validation in checking the URL when moving from one page to the next.
- Steps have also been refactored into the steps.js file to make the test file more readable and make steps more reusable.

## How to review

[1] Code review
[2] Rebase the branch over BAU/deploy-authdev1, add test services API key to the authdev1.tfvars file and run ./deploy-sandpit.sh. See that the authdev1-smoke-cra passes in cloudwatch.
