### PR TITLE
BAU: Fix smoke test deployment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,28 @@
-## What?
+## What
 
-Please include a summary of the change.
+<!-- Describe what you have changed and why -->
 
-## Why?
+## How to review
 
-Please include reason for the change and any other relevant context.
+<!-- Describe the steps required to review this PR.
+For example:
+
+1. Code Review
+1. Deploy to sandpit with `./deploy-sandpit.sh -a`
+1. Ensure that resources `x`, `y` and `z` were not changed
+1. Visit [some url](https://some.sandpit.url/to/visit)
+1. Log in
+1. Ensure `x` message appears in a modal
+-->
 
 ## Related PRs
 
-Please include links to PRs in other repositories relevant to this PR.
-Delete this section if not needed.
+<!-- Links to PRs in other repositories that are relevant to this PR.
+
+This could be:
+  - PRs that depend on this one
+  - PRs this one depends on
+  - If this work is being duplicated in other repos, other PRs
+  - PRs which just provide context to this one.
+
+Delete this section if not needed! -->

--- a/.github/workflows/build-and-deploy-dev.yml
+++ b/.github/workflows/build-and-deploy-dev.yml
@@ -61,7 +61,8 @@ jobs:
           VERSION="$(echo "$S3_RESPONSE" | jq .VersionId -r)"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
-      - name: Start signing job for ${{ matrix.module }}
+      - name: Run signing job for ${{ matrix.module }}
+        id: sign-module
         run: |
           SIGNER_RESPONSE="$(aws signer start-signing-job \
             --profile-name "${SIGNING_PROFILE}" \
@@ -69,6 +70,35 @@ jobs:
             --destination "s3={bucketName=${DESTINATION_BUCKET},prefix=signed-${{ matrix.module }}-${{ github.sha }}-}")"
           JOB_ID="$(echo "$SIGNER_RESPONSE" | jq .jobId -r)"
           aws signer wait successful-signing-job --job-id "$JOB_ID"
+
+          SIGNED_OBJECT="$(aws signer describe-signing-job --job-id "${JOB_ID}" --query "signedObject.s3.key" --output=text)"
+
+          echo "Object signed: ${SIGNED_OBJECT}"
+          echo "SIGNED_OBJECT_KEY=${SIGNED_OBJECT}" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare GHA artifact
+        id: create_artifact
+        run: |
+          artifact_dir="/tmp/artifacts"
+
+          mkdir -p "${artifact_dir}"
+
+          aws s3api get-object \
+            --bucket ${{ env.DESTINATION_BUCKET }} \
+            --key ${{ steps.sign-module.outputs.SIGNED_OBJECT_KEY }} \
+            "${artifact_dir}/${{ matrix.module }}.zip"
+
+          {
+            echo "artifact_dir=${artifact_dir}"
+            echo "code_sha=${{ github.sha }}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifacts
+        id: upload-artifacts
+        uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 # v4.3.5
+        with:
+          name: signed-${{ matrix.module }}
+          path: "${{ steps.create_artifact.outputs.artifact_dir }}/"
 
   deploy:
     runs-on: ubuntu-latest
@@ -89,29 +119,18 @@ jobs:
           role-to-assume: ${{ env.DEPLOY_ROLE }}
           aws-region: eu-west-2
 
-      - name: Download and copy Smoke Tests signed lambda zip
-        working-directory: ci/terraform
-        run: |
-          aws s3 cp s3://${{ env.DESTINATION_BUCKET }} ./artifacts \
-            --recursive --exclude "*" \
-            --include "signed-canary-${{ github.sha }}-*"
-          mv artifacts/signed-canary-*.zip artifacts/smoke-tests.zip
+      - name: Download signed artifacts
+        id: download_artifact
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          pattern: signed-*
+          path: ci/terraform/artifacts/
+          merge-multiple: true
 
-      - name: Download and copy Alerts signed lambda zip
-        working-directory: ci/terraform
+      - name: Rename Canary -> Smoke Tests
+        working-directory: ci/terraform/artifacts/
         run: |
-          aws s3 cp s3://${{ env.DESTINATION_BUCKET }} ./artifacts \
-            --recursive --exclude "*" \
-            --include "signed-alerts-${{ github.sha }}-*"
-          mv artifacts/signed-alerts-*.zip artifacts/alerts.zip
-
-      - name: Download and copy Heartbeat signed lambda zip
-        working-directory: ci/terraform
-        run: |
-          aws s3 cp s3://${{ env.DESTINATION_BUCKET }} ./artifacts \
-            --recursive --exclude "*" \
-            --include "signed-heartbeat-${{ github.sha }}-*"
-          mv artifacts/signed-heartbeat-*.zip artifacts/heartbeat.zip
+          mv canary.zip smoke-tests.zip
 
       - name: Upload Smoke Tests Terraform files
         working-directory: ci/terraform

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -64,7 +64,8 @@ jobs:
           VERSION="$(echo "$S3_RESPONSE" | jq .VersionId -r)"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
-      - name: Start signing job for ${{ matrix.module }}
+      - name: Run signing job for ${{ matrix.module }}
+        id: sign-module
         run: |
           SIGNER_RESPONSE="$(aws signer start-signing-job \
             --profile-name "${SIGNING_PROFILE}" \
@@ -72,6 +73,35 @@ jobs:
             --destination "s3={bucketName=${DESTINATION_BUCKET},prefix=signed-${{ matrix.module }}-${{ github.sha }}-}")"
           JOB_ID="$(echo "$SIGNER_RESPONSE" | jq .jobId -r)"
           aws signer wait successful-signing-job --job-id "$JOB_ID"
+
+          SIGNED_OBJECT="$(aws signer describe-signing-job --job-id "${JOB_ID}" --query "signedObject.s3.key" --output=text)"
+
+          echo "Object signed: ${SIGNED_OBJECT}"
+          echo "SIGNED_OBJECT_KEY=${SIGNED_OBJECT}" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare GHA artifact
+        id: create_artifact
+        run: |
+          artifact_dir="/tmp/artifacts"
+
+          mkdir -p "${artifact_dir}"
+
+          aws s3api get-object \
+            --bucket ${{ env.DESTINATION_BUCKET }} \
+            --key ${{ steps.sign-module.outputs.SIGNED_OBJECT_KEY }} \
+            "${artifact_dir}/${{ matrix.module }}.zip"
+
+          {
+            echo "artifact_dir=${artifact_dir}"
+            echo "code_sha=${{ github.sha }}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifacts
+        id: upload-artifacts
+        uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 # v4.3.5
+        with:
+          name: signed-${{ matrix.module }}
+          path: "${{ steps.create_artifact.outputs.artifact_dir }}/"
 
   deploy:
     runs-on: ubuntu-latest
@@ -92,29 +122,18 @@ jobs:
           role-to-assume: ${{ env.DEPLOY_ROLE }}
           aws-region: eu-west-2
 
-      - name: Download and copy Smoke Tests signed lambda zip
-        working-directory: ci/terraform
-        run: |
-          aws s3 cp s3://${{ env.DESTINATION_BUCKET }} ./artifacts \
-            --recursive --exclude "*" \
-            --include "signed-canary-${{ github.sha }}-*"
-          mv artifacts/signed-canary-*.zip artifacts/smoke-tests.zip
+      - name: Download signed artifacts
+        id: download_artifact
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          pattern: signed-*
+          path: ci/terraform/artifacts/
+          merge-multiple: true
 
-      - name: Download and copy Alerts signed lambda zip
-        working-directory: ci/terraform
+      - name: Rename Canary -> Smoke Tests
+        working-directory: ci/terraform/artifacts/
         run: |
-          aws s3 cp s3://${{ env.DESTINATION_BUCKET }} ./artifacts \
-            --recursive --exclude "*" \
-            --include "signed-alerts-${{ github.sha }}-*"
-          mv artifacts/signed-alerts-*.zip artifacts/alerts.zip
-
-      - name: Download and copy Heartbeat signed lambda zip
-        working-directory: ci/terraform
-        run: |
-          aws s3 cp s3://${{ env.DESTINATION_BUCKET }} ./artifacts \
-            --recursive --exclude "*" \
-            --include "signed-heartbeat-${{ github.sha }}-*"
-          mv artifacts/signed-heartbeat-*.zip artifacts/heartbeat.zip
+          mv canary.zip smoke-tests.zip
 
       - name: Upload Smoke Tests Terraform files
         working-directory: ci/terraform

--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,4 @@ keys/
 .vscode/
 ci/terraform/.terraform/
 ci/terraform/*.plan
+.terraform


### PR DESCRIPTION
## What?

The previous change caused the workflow [to fail and not deploy changes to the smoke tests](https://github.com/govuk-one-login/authentication-smoke-tests/actions/runs/10146347076).

Instead of the previous method of pulling in the signed smoke test zips
during the `deploy` phase, instead, retrieve them immediately after the
signing job completes in `build`, and push them up to the GHA artifact
store. Then retrieve from this store in `deploy`.

This has two benefits:

1. The artifacts are easily downloadable from github, so developers
   can see exactly what it is that this workflow deployed
2. We no longer have to use the `aws s3 cp` globbing to retrieve the
   correct artifact version: we can just retrieve the specific key
   that the signing job returns.

## How to review

Ensure that this branch pushes the correct artifact up to S3 (ran in dev here: https://github.com/govuk-one-login/authentication-smoke-tests/actions/runs/10252174826)