### PR TITLE
BAU: Group AWS npm dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: daily
       time: "03:00"
+    groups:
+      npm-aws-dependencies:
+        patterns:
+          - "@aws-sdk/*"
     open-pull-requests-limit: 100
     target-branch: main
     commit-message:
@@ -14,6 +18,10 @@ updates:
     schedule:
       interval: daily
       time: "03:00"
+    groups:
+      npm-aws-dependencies:
+        patterns:
+          - "@aws-sdk/*"
     open-pull-requests-limit: 100
     target-branch: main
     commit-message:
@@ -32,6 +40,10 @@ updates:
     schedule:
       interval: daily
       time: "03:00"
+    groups:
+      npm-aws-dependencies:
+        patterns:
+          - "@aws-sdk/*"
     open-pull-requests-limit: 100
     target-branch: main
     commit-message:


### PR DESCRIPTION
## What

This reduces the number of PRs that have similar version bumps for AWS npm dependencies.

At the time of drafting this PR, we have 6 open PRs for AWS npm updates. This would reduce that to 3 and tie intrinsically linked dependency updates together for each application in this repo.

- https://github.com/govuk-one-login/authentication-smoke-tests/pull/927
- https://github.com/govuk-one-login/authentication-smoke-tests/pull/926
- https://github.com/govuk-one-login/authentication-smoke-tests/pull/925
- https://github.com/govuk-one-login/authentication-smoke-tests/pull/924
- https://github.com/govuk-one-login/authentication-smoke-tests/pull/923
- https://github.com/govuk-one-login/authentication-smoke-tests/pull/922

We can see with the last two how they can become desynced.


## How to review

1. Code Review
