### PR TITLE
BAU: Switch SonarCloud GHA for SonarQube

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@02ef91109b2d589e757aefcfb2854c2783fd7b19
+        uses: sonarsource/sonarqube-scan-action@1b442ee39ac3fa7c2acdd410208dcb2bcfaae6c4 # v4.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar-analysis-on-merge.yml
+++ b/.github/workflows/sonar-analysis-on-merge.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@02ef91109b2d589e757aefcfb2854c2783fd7b19
+        uses: sonarsource/sonarqube-scan-action@1b442ee39ac3fa7c2acdd410208dcb2bcfaae6c4 # v4.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## What

`sonarsource/sonarcloud-github-action` has been deprecated ([1]).

> This action is deprecated and will be removed in a future release. Please use the sonarqube-scan-action action instead. The sonarqube-scan-action is a drop-in replacement for this action.

Instead the pre-existing `sonarsource/sonarqube-scan-action` ([2]) has replaced it.

As quoted above, this should be a "drop-in replacement". Version 4.1.0 is the latest at the this time ([3])

[1] https://github.com/SonarSource/sonarcloud-github-action
[2] https://community.sonarsource.com/t/the-new-release-of-github-action-for-sonarqube-v-4-1-0-server-and-cloud/131399
[3] https://github.com/SonarSource/sonarqube-scan-action/releases/tag/v4.1.0

## How to review

1. Code Review