### PR TITLE
BAU: Add eslint dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
       npm-aws-dependencies:
         patterns:
           - "@aws-sdk/*"
+      npm-eslint-dependencies:
+        patterns:
+          - "*eslint*"
     open-pull-requests-limit: 100
     target-branch: main
     commit-message:


### PR DESCRIPTION
## What

We have separate dependabot PRs being raised for eslint dependencies, which we have a few and are generally updated in tandem. They should really be handled in the same PR, which this grouping will achieve.

## How to review

1. Code Review

## Related PRs

Here are some examples of PRs raised at the same time that should be tied together:

- https://github.com/govuk-one-login/authentication-smoke-tests/pull/1033
- https://github.com/govuk-one-login/authentication-smoke-tests/pull/1032
