### PR TITLE
AUT-3694: updating the Cron job to run  smoke-test every minute in prod

### DIFF
--- a/ci/terraform/production-overrides.tfvars
+++ b/ci/terraform/production-overrides.tfvars
@@ -14,4 +14,4 @@ sign_in_metric_alarm_enabled   = true
 sign_in_heartbeat_ping_enabled = true
 
 #This will run the smoke tests every 3 minutes 24/7
-smoke_test_cron_expression = "0/03 * * * ? *"
+smoke_test_cron_expression = "* * * * ? *"


### PR DESCRIPTION
## What

AUT-3694 : As part of Auth frontend migration we want to run Smoke test every minute in prod so  updating the Cron job to run  smoke-test every minute in prod

## How to review

1. Code Review
