### PR TITLE
BAU: revert to run integration smoke tests every 3 mins

### DIFF
--- a/ci/terraform/integration-overrides.tfvars
+++ b/ci/terraform/integration-overrides.tfvars
@@ -13,6 +13,5 @@ ipv_sign_in_heartbeat_ping_enabled = false
 sign_in_metric_alarm_enabled   = true
 sign_in_heartbeat_ping_enabled = true
 
-#This will run the smoke tests every 1 minutes between 09:00 - 17:00 (UTC) Mon - Fri
-# Setting cron to run every 1 min for secure  pileine migration once migration is done will revert back to run every 3 min
-smoke_test_cron_expression = "* 08-17 ? * MON-FRI *"
+#This will run the smoke tests every 3 minutes between 08:00 - 17:00 (UTC) Mon - Fri
+smoke_test_cron_expression = "0/03 08-17 ? * MON-FRI *"


### PR DESCRIPTION

## What

Revert to run integration smoke tests every 3 mins

Suspected flakiness caused by increased frequency

## How to review

1. Code Review

## Related PRs

https://github.com/govuk-one-login/authentication-smoke-tests/pull/1026