### PR TITLE
AUT-4043: Update smoke test numbers for sandpit canaries

### DIFF
--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -29,9 +29,10 @@ test_services_api_key                 = "not-a-real-key"
 username_create_account               = "not-real-username"
 
 # The following are all reserved by Ofcom 'for use in drama': https://www.ofcom.org.uk/phones-and-broadband/phone-numbers/numbers-for-drama/
+# They are also Notify test numbers: https://docs.notifications.service.gov.uk/rest-api.html#phone-numbers
 phone_create_account     = "07700900222"
-ipv_smoke_test_phone     = "07700900333"
-sign_in_smoke_test_phone = "07700900333"
+ipv_smoke_test_phone     = "07700900000"
+sign_in_smoke_test_phone = "07700900111"
 
 alerts_code_s3_key                      = "di-monitoring-utils/alerts.zip/sandpit-smoketest"
 heartbeat_code_s3_key                   = "di-monitoring-utils/heartbeat.zip/sandpit-smoketest"


### PR DESCRIPTION
* Makes sure that each of these numbers are different, meaning we can run the tests at the same time without risk of interference
* Uses the notify test numbers[1] to ensure that these do not trigger actual failed attempts to send to a number

This comes off the back of an incident where our smoke tests were using an offcom reserved number (07700900333) that is not also a notify test number. This was causing notify to attempt to send to this number but failing each time a smoke test using this number ran. At some point, we had enough failures to this number to trigger a warning from Notify, so we are fixing usages of this number to instead be one of the reserved notify test numbers.

This was largely a problem with the integration and production values which are stored in aws rather than the sandpit values which are changed here. The sandpit values are less of a problem since the sandpit canaries don't run by default, but updating here to save any future warnings.

[1] [https://docs.notifications.service.gov.uk/rest-api.html\#phone-numbers](https://docs.notifications.service.gov.uk/rest-api.html/#phone-numbers)