### PR TITLE
BAU: Remove old canary lambda when updating

### DIFF
--- a/ci/terraform/modules/canary/canary.tf
+++ b/ci/terraform/modules/canary/canary.tf
@@ -12,6 +12,8 @@ resource "aws_synthetics_canary" "smoke_tester_canary" {
   s3_key     = var.canary_source_key
   s3_version = var.canary_source_version_id
 
+  delete_lambda = true // This will delete the lambda function when the canary is updated
+
   success_retention_period = 1
   failure_retention_period = 14
 


### PR DESCRIPTION
## What

Previously, the lambda associated with the canary would be left behind
when updating the canary. Now, we create a new lambda, and delete the
old one.

## How to review

0. Look at the AWS console in staging, take note of the latest canary lambdas
1. make a change to the lambda code (so the canary is seen as 'different')
2. deploy to sandpit
3. observe that the previously noted lambdas have been removed, and new ones created in their place

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
