### PR TITLE
Revert "AUT-3694: updating the Cron job to run  smoke-test every minute in prod"

### DIFF
--- a/ci/terraform/production-overrides.tfvars
+++ b/ci/terraform/production-overrides.tfvars
@@ -14,4 +14,4 @@ sign_in_metric_alarm_enabled   = true
 sign_in_heartbeat_ping_enabled = true
 
 #This will run the smoke tests every 3 minutes 24/7
-smoke_test_cron_expression = "* * * * ? *"
+smoke_test_cron_expression = "0/03 * * * ? *"


### PR DESCRIPTION
Reverts govuk-one-login/authentication-smoke-tests#1039 which was temp increase in frequency of Smoke test in prod for frontend Migration 

Auth Prod Frontend is Successfully migrated and we have monitored the change for 2 weeks all good so reverting this change