### PR TITLE
Revert "BAU: Bump express-openid-connect from 2.17.1 to 2.18.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/client-ssm": "^3.777.0",
     "crypto": "^1.0.1",
     "express": "^4.21.2",
-    "express-openid-connect": "^2.18.0"
+    "express-openid-connect": "^2.17.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1489,10 +1489,10 @@ cookie@0.7.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.1.tgz#2f73c42142d5d5cf71310a74fc4ae61670e5dbc9"
   integrity sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==
 
-cookie@^0.7.1:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
-  integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
+cookie@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz"
+  integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
 
 cross-spawn@^7.0.6:
   version "7.0.6"
@@ -1742,19 +1742,19 @@ etag@~1.8.1:
   resolved "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
-express-openid-connect@^2.18.0:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/express-openid-connect/-/express-openid-connect-2.18.0.tgz#23cb40ad65232b7291deca157e24890ec1a17a55"
-  integrity sha512-UynJUKAn29jYtXGnjLqn22YES2GNn5GhT7iEiN3W7EaWMt/8dg39UJM9av4R44rPwEE4JNzIkd/Gg4InIiMQNQ==
+express-openid-connect@^2.17.1:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/express-openid-connect/-/express-openid-connect-2.17.1.tgz#b7c6169d5b694c7ab791671dd3af3f8346611cc6"
+  integrity sha512-5pVK6PNV09x6UN29R9Mer0XF3hwQq2HxiFsjZvLuIQ9ezeTUGbqrefzBOpzciz1S/1WWVaVPDIcj4EBpD8WB3Q==
   dependencies:
     base64url "^3.0.1"
     clone "^2.1.2"
-    cookie "^0.7.1"
+    cookie "^0.5.0"
     debug "^4.3.4"
     futoin-hkdf "^1.5.1"
     http-errors "^1.8.1"
     joi "^17.7.0"
-    jose "^2.0.7"
+    jose "^2.0.6"
     on-headers "^1.0.2"
     openid-client "^4.9.1"
     url-join "^4.0.1"
@@ -2087,7 +2087,7 @@ joi@^17.7.0:
     "@sideway/formula" "^3.0.1"
     "@sideway/pinpoint" "^2.0.0"
 
-jose@^2.0.5, jose@^2.0.7:
+jose@^2.0.5, jose@^2.0.6:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/jose/-/jose-2.0.7.tgz#3aabbaec70bff313c108b9406498a163737b16ba"
   integrity sha512-5hFWIigKqC+e/lRyQhfnirrAqUdIPMB7SJRqflJaO29dW7q5DFvH1XCSTmv6PQ6pb++0k6MJlLRoS0Wv4s38Wg==


### PR DESCRIPTION
Reverts govuk-one-login/authentication-smoke-tests#1093