### PR TITLE
BAU: Update step to match IPV content change

### DIFF
--- a/src/steps.js
+++ b/src/steps.js
@@ -110,8 +110,7 @@ const ipvHandOff = async (page) => {
     log.info(pageTitleForConsole);
 
     const hasReachedIPV =
-      (await page.title()) ===
-      "Do you live in the UK, the Channel Islands or the Isle of Man? – GOV.UK One Login";
+      (await page.title()) === "Where do you live? – GOV.UK One Login";
 
     if (!hasReachedIPV) {
       throw new Error(`Failed at IPV Hand-off step`);


### PR DESCRIPTION
## What

IPV recently updated the title string of the IPV handoff expected page, meaning the IPV smoke test fails without this change to match.

## How to review

1. Code Review

## Related PRs

- https://github.com/govuk-one-login/ipv-core-front/pull/2019
