### PR TITLE
Use Slack ID for all low environment in alert lambda

### DIFF
--- a/alerts/alerts.js
+++ b/alerts/alerts.js
@@ -65,7 +65,7 @@ const formatMessage = (snsMessage, colorCode, snsMessageFooter) => {
 
 const buildMessageRequest = (snsMessage, colorCode, snsMessageFooter) => {
   const body = formatMessage(snsMessage, colorCode, snsMessageFooter);
-  if (process.env.DEPLOY_ENVIRONMENT === "integration") {
+  if (process.env.DEPLOY_ENVIRONMENT !== "production") {
     body.channel = process.env.SLACK_CHANNEL_ID;
   }
   return {


### PR DESCRIPTION
## What

Use Slack ID for all low environment in alert lambda

## How to review


1. Code Review

