### PR TITLE
BAU: Add rate limit for smoke test RPs

### DIFF
--- a/ci/terraform/stub-rp-clients.tf
+++ b/ci/terraform/stub-rp-clients.tf
@@ -95,5 +95,8 @@ resource "aws_dynamodb_table_item" "stub_rp_client" {
     SmokeTest = {
       N = var.stub_rp_clients[count.index].smoke_test
     }
+    RateLimit = {
+      N = 5
+    }
   })
 }


### PR DESCRIPTION
This enforces a rate limit of 5 req/minute from the smoke test RP