### PR TITLE
ATO-1859: update prod smoke tests to run every minute

### DIFF
--- a/ci/terraform/production-overrides.tfvars
+++ b/ci/terraform/production-overrides.tfvars
@@ -13,5 +13,5 @@ ipv_sign_in_heartbeat_ping_enabled = false
 sign_in_metric_alarm_enabled   = true
 sign_in_heartbeat_ping_enabled = true
 
-#This will run the smoke tests every 3 minutes 24/7
-smoke_test_cron_expression = "0/03 * * * ? *"
+#This will run the smoke tests every minute 24/7
+smoke_test_cron_expression = "0/01 * * * ? *"

--- a/template.yaml
+++ b/template.yaml
@@ -152,7 +152,7 @@ Mappings:
     #   HeartbeatPingEnabled: "Yes"
     #   CanaryScriptbucket: ""
     #   BackendAccountID: "172348255554"
-    #   SmokeTestCronExpression: "cron(0/03 * * * ? *)"
+    #   SmokeTestCronExpression: "cron(0/01 * * * ? *)"
     #   StartIPVCanaryAfterCreation: true
     #   IsSlackNotifyEnabled: "Yes"
 


### PR DESCRIPTION
## What

Update the smoke tests in prod to run every minute instead of every 3 minutes. This is because of incident INC0014859, where with the current frequency, it can take up to 5.5 minutes from downtime to us being alerted, and it was decided that there's not downside to running these more often, so the maximum downtime to being alerted has been reduced to 1.5 minutes with this frequency.
