### PR TITLE
AUT-4595: Set express-openid-connect client timeout

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -29,6 +29,7 @@ const startClient = async (
         scope: scope,
         vtr: isP2LevelOfConfidenceJourney ? '["P2.Cl.Cm"]' : '["Cl.Cm"]',
       },
+      httpTimeout: 10000,
     })
   );
   app.get("/", async (req, res) => {


### PR DESCRIPTION
## What

By default this is 5 seconds. Due to seeing cold starts of our RP stub resulting in integration smoke test failures during OIDC callback, we're bumping the timeout to 10 seconds.

## How to review

1. Code Review