### PR TITLE
BAU: Hide most characters of Cronitor key

### DIFF
--- a/heartbeat/heartbeat.js
+++ b/heartbeat/heartbeat.js
@@ -3,10 +3,13 @@ const cronitor = require("cronitor")(process.env.CRONITOR_API_KEY);
 // eslint-disable-next-line no-unused-vars
 const handler = async function (event, context) {
   const monitorKey = process.env.CRONITOR_MONITOR_KEY;
-  console.log("cronitor ping monitor " + monitorKey);
+  const keyExcerpt = monitorKey.slice(-2);
+  console.log("cronitor ping monitor ending " + keyExcerpt);
   const monitor = new cronitor.Monitor(monitorKey);
   return monitor.ping().then((response) => {
-    return "cronitor ping monitor " + monitorKey + " returns: " + response;
+    return (
+      "cronitor ping monitor ending " + keyExcerpt + " returns: " + response
+    );
   });
 };
 


### PR DESCRIPTION
## What

Instead of logging the full key, hide all but the last 3. This means less risk of exposure.

## How to review

1. Code Review