### PR TITLE
bau: Add s3 object to synthetics canary to force new deployment

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -986,6 +986,7 @@ Resources:
             ArtifactSourceBucket,
           ]
         S3Key: synthetics.zip
+        S3ObjectVersion: !GetAtt GetSyntheticsZipVersion.Version
         Handler: canary-sign-in.handler
       Tags:
         - Key: Environment
@@ -1050,6 +1051,7 @@ Resources:
             ArtifactSourceBucket,
           ]
         S3Key: synthetics.zip
+        S3ObjectVersion: !GetAtt GetSyntheticsZipVersion.Version
         Handler: canary-sign-in-with-ipv.handler
       Tags:
         - Key: Environment
@@ -1114,6 +1116,7 @@ Resources:
             ArtifactSourceBucket,
           ]
         S3Key: synthetics.zip
+        S3ObjectVersion: !GetAtt GetSyntheticsZipVersion.Version
         Handler: canary-create-account.handler
       Tags:
         - Key: Environment
@@ -1706,21 +1709,76 @@ Resources:
       Principal: events.amazonaws.com
       SourceArn: !GetAtt CreateAccountHeartbeatRule.Arn
 
-Outputs:
-  SignInCanaryId:
-    Description: "ID of the SignInCanary"
-    Value: !GetAtt SignInCanary.Id
-    Export:
-      Name: !Sub "${AWS::StackName}-SignInCanary-Id"
+  GetS3VersionFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub "${Environment}-get-s3-version"
+      Runtime: nodejs20.x
+      Handler: index.handler
+      Role: !GetAtt GetS3VersionRole.Arn
+      Code:
+        ZipFile: |
+          const { S3Client, HeadObjectCommand } = require('@aws-sdk/client-s3');
+          const response = require('cfn-response');
 
-  SignInWithIPVCanaryId:
-    Description: "ID of the SignInWithIPVCanary"
-    Value: !GetAtt SignInWithIPVCanary.Id
-    Export:
-      Name: !Sub "${AWS::StackName}-SignInWithIPVCanary-Id"
+          exports.handler = async (event, context) => {
+              const s3 = new S3Client({});
 
-  CreateAccountCanaryId:
-    Description: "ID of the CreateAccountCanary"
-    Value: !GetAtt CreateAccountCanary.Id
-    Export:
-      Name: !Sub "${AWS::StackName}-CreateAccountCanary-Id"
+              try {
+                  const { Bucket, Key } = event.ResourceProperties;
+
+                  const command = new HeadObjectCommand({ Bucket, Key });
+                  const result = await s3.send(command);
+
+                  await response.send(event, context, response.SUCCESS, {
+                      Version: result.VersionId || 'null'
+                  });
+              } catch (error) {
+                  console.error('Error:', error);
+                  await response.send(event, context, response.FAILED, {});
+              }
+          };
+
+  GetS3VersionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: S3Access
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                Resource: !Sub
+                  - "${BucketArn}/*"
+                  - BucketArn: !Sub
+                      - "arn:aws:s3:::${Bucket}"
+                      - Bucket:
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref Environment,
+                            ArtifactSourceBucket,
+                          ]
+
+  GetSyntheticsZipVersion:
+    Type: AWS::CloudFormation::CustomResource
+    Properties:
+      ServiceToken: !GetAtt GetS3VersionFunction.Arn
+      Bucket:
+        !FindInMap [
+          EnvironmentConfiguration,
+          !Ref Environment,
+          ArtifactSourceBucket,
+        ]
+      Key: synthetics.zip


### PR DESCRIPTION
## What

synthetics canary are not getting deployed so we need to pass the version ID s3 object , PR is adding a custom resource to fetch the head version s3 object ( synthetics.zip) and pass as ref to Canary deployment 

Add s3 object to synthetics canary to force new deployment

## How to review


1. Code Review
1. Deploy to authdev3 and see canary is getting deployed 

