### PR TITLE
BAU: Override qs to 6.15.2 to fix CVE-2026-8723

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4491,9 +4491,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "overrides": {
     "minimatch@<3.1.3": ">=3.1.3",
-    "fast-xml-parser": ">=5.5.9"
+    "fast-xml-parser": ">=5.5.9",
+    "qs": ">=6.15.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",


### PR DESCRIPTION
## What

- CVE-2026-8723: prototype pollution in qs query string parser. Adding override to constrain transitive qs dependency to >=6.15.2 where the fix was released.

## How to review

1. Code Review