### PR TITLE
AUT-5555: Add skip step for sign-in canary when a passkey prompt is shown

### DIFF
--- a/src/canary-sign-in.js
+++ b/src/canary-sign-in.js
@@ -69,6 +69,8 @@ const basicCustomEntryPoint = async () => {
 
   await steps.submitOtpCode(page);
 
+  await steps.skipPasskeyPromptIfPresent(page);
+
   await steps.microclientUserInfo(page, email);
 
   return "success";

--- a/src/steps.js
+++ b/src/steps.js
@@ -90,6 +90,21 @@ const submitOtpCode = async (page, stepName = "Submit OTP code") => {
   });
 };
 
+const skipPasskeyPromptIfPresent = async (page) => {
+  await synthetics.executeStep("Skip passkey prompt if present", async () => {
+    const url = await page.url();
+    if (url.includes("create-passkey")) {
+      log.info("Passkey prompt detected — clicking skip");
+      await Promise.all([
+        page.click('button[name="createPasskeyOption"][value="skip"]'),
+        page.waitForNavigation(),
+      ]);
+    } else {
+      log.info("No passkey prompt — continuing");
+    }
+  });
+};
+
 const microclientUserInfo = async (page, email) => {
   await synthetics.executeStep("Microclient user info", async () => {
     await page.content();
@@ -229,6 +244,7 @@ module.exports = {
   submitPassword,
   enterOtpCode,
   submitOtpCode,
+  skipPasskeyPromptIfPresent,
   ipvHandOff,
   microclientUserInfo,
   clickCreateAccount,


### PR DESCRIPTION
## What

Add skip step for sign-in canary when a passkey prompt is shown

When signing in a user will not necessarily see a passkey prompt screen. This could be due to one of the prompt rules:

- Phased rollout.  Initially only a certain percentage of users will see the prompt.
- The user has clicked skip in the last 7 days (which will be true for the smoketests)
- For additional prompt rules see the functional design

As the prompt is not shown in all cases a step has been added to the smoketest to ignore it and click skip if it is shown.

### Run where passkey prompt not shown

<img width="866" height="587" alt="Screenshot 2026-07-13 at 17 57 22" src="https://github.com/user-attachments/assets/d4a34bdb-9a9e-4b5f-9975-df9b37634b9b" />

### Run where passkey prompt shown

<img width="871" height="557" alt="Screenshot 2026-07-13 at 17 55 36" src="https://github.com/user-attachments/assets/40e0c186-8f08-42cb-aa57-073bd2dd212e" />

## How to review

1. Code Review
1. Deploy to authdev3 with `./sam-deploy-authdevs.sh` 
1. Check smoke test run screenshot to see that the test handles journeys both with and without the passkey prompt

Currently deployed to authdev3

## Related PRs

