### PR TITLE
BAU: Suppress elasticache service alerts

### DIFF
--- a/alerts/alerts.js
+++ b/alerts/alerts.js
@@ -1,5 +1,18 @@
 const { getParameter } = require("./aws");
 
+const isSuppressedAlert = (snsMessage) => {
+  if (
+    JSON.stringify(snsMessage).includes("ElastiCache") &&
+    snsMessage["ElastiCache:ServiceUpdateAvailable"]
+  ) {
+    console.log(
+      `Suppressing ElastiCache ServiceUpdateAvailable notification for cluster: ${snsMessage["ElastiCache:ServiceUpdateAvailable"]}`
+    );
+    return true;
+  }
+  return false;
+};
+
 const formatMessage = (snsMessage, colorCode, snsMessageFooter) => {
   if (JSON.stringify(snsMessage).includes("ElastiCache")) {
     return {
@@ -106,6 +119,11 @@ const handler = async function (event, context) {
 
   let snsMessage = JSON.parse(event.Records[0].Sns.Message);
   console.log(snsMessage);
+
+  if (isSuppressedAlert(snsMessage)) {
+    return { statusCode: 200, body: "Alert suppressed" };
+  }
+
   if (snsMessage.NewStateValue === "OK") {
     colorCode = process.env.OK_COLOR || "#36a64f";
   }
@@ -125,4 +143,4 @@ const handler = async function (event, context) {
   }
 };
 
-module.exports = { handler };
+module.exports = { handler, isSuppressedAlert };

--- a/alerts/test/alerts.test.js
+++ b/alerts/test/alerts.test.js
@@ -5,7 +5,7 @@ const chai = require("chai");
 
 chai.use(sinonChai);
 
-const { handler } = require("../alerts");
+const { handler, isSuppressedAlert } = require("../alerts");
 
 describe("alerts handler", () => {
   let fetchStub;
@@ -210,6 +210,105 @@ describe("alerts handler", () => {
 
       const body = JSON.parse(fetchStub.firstCall.args[1].body);
       expect(body.attachments[0].fields[1].value).to.equal("my-account");
+    });
+  });
+
+  describe("alert suppression", () => {
+    it("should suppress ElastiCache ServiceUpdateAvailable notifications", async () => {
+      fetchStub.resolves({ text: () => Promise.resolve("ok") });
+
+      const snsMessage = {
+        "Service Update Name": "elasticache-20260608-intel",
+        "Replication Group ID": "production-sessions-store",
+        "ElastiCache:ServiceUpdateAvailable": "production-sessions-store",
+      };
+
+      const event = {
+        Records: [
+          {
+            Sns: { Type: "Notification", Message: JSON.stringify(snsMessage) },
+          },
+        ],
+      };
+
+      const result = await handler(event, {});
+
+      expect(fetchStub).to.not.have.been.called;
+      expect(result.statusCode).to.equal(200);
+      expect(result.body).to.equal("Alert suppressed");
+    });
+
+    it("should not suppress other ElastiCache notifications", async () => {
+      fetchStub.resolves({ text: () => Promise.resolve("ok") });
+
+      const snsMessage = { "ElastiCache:event": "my-cluster" };
+
+      const event = {
+        Records: [
+          {
+            Sns: { Type: "Notification", Message: JSON.stringify(snsMessage) },
+          },
+        ],
+      };
+
+      await handler(event, {});
+
+      expect(fetchStub).to.have.been.calledWith(
+        "https://hooks.slack.com/test",
+        sinon.match.has("method", "post")
+      );
+    });
+
+    it("should not suppress regular alarm notifications", async () => {
+      fetchStub.resolves({ text: () => Promise.resolve("ok") });
+
+      const snsMessage = {
+        AlarmName: "TestAlarm",
+        AlarmDescription: "Something broke",
+        NewStateValue: "ALARM",
+        AWSAccountId: "123456789",
+      };
+
+      const event = {
+        Records: [
+          {
+            Sns: { Type: "Notification", Message: JSON.stringify(snsMessage) },
+          },
+        ],
+      };
+
+      await handler(event, {});
+
+      expect(fetchStub).to.have.been.calledWith(
+        "https://hooks.slack.com/test",
+        sinon.match.has("method", "post")
+      );
+    });
+  });
+
+  describe("isSuppressedAlert", () => {
+    it("should return true for ServiceUpdateAvailable messages", () => {
+      const message = {
+        "Service Update Name": "elasticache-20260608-intel",
+        "Replication Group ID": "production-sessions-store",
+        "ElastiCache:ServiceUpdateAvailable": "production-sessions-store",
+      };
+      expect(isSuppressedAlert(message)).to.be.true;
+    });
+
+    it("should return false for other ElastiCache messages", () => {
+      const message = { "ElastiCache:event": "my-cluster" };
+      expect(isSuppressedAlert(message)).to.be.false;
+    });
+
+    it("should return false for non-ElastiCache messages", () => {
+      const message = {
+        AlarmName: "TestAlarm",
+        AlarmDescription: "Test",
+        NewStateValue: "ALARM",
+        AWSAccountId: "123456789",
+      };
+      expect(isSuppressedAlert(message)).to.be.false;
     });
   });
 });


### PR DESCRIPTION

## What

Suppress elasticache service alerts

A patch being available generated an alert as we are publishing all elasticache alerts.  Add a filter to the alerts lambda to filter out alerts of type 'ElastiCache:ServiceUpdateAvailable'

## How to review

1. Code Review
1. Deploy to authdev3 with `./sam-deploy-authdevs.sh`
1. Generate an alert by failing over Elasticache

## Related

See https://gds.slack.com/archives/C02HCLREVV5/p1784231264202679

https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/ElastiCacheSNS.html#ElastiCacheSNS.Events

