### PR TITLE
AUT-5555: Add local canary runner for testing Synthetics smoke tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,6 +41,12 @@ module.exports = [
     ignores: ["eslint.config.js"],
   },
   {
+    files: ["local-testing/**/*.js"],
+    rules: {
+      "no-unused-vars": ["error", { args: "none" }],
+    },
+  },
+  {
     files: ["**/test/**/*.js"],
     languageOptions: {
       globals: {

--- a/local-testing/README.md
+++ b/local-testing/README.md
@@ -1,0 +1,108 @@
+# Local Canary Testing
+
+Run Synthetics canaries locally on your Mac without Docker or the Lambda layer.
+
+Uses a local Puppeteer browser with mocked Synthetics modules — the canary code
+makes real AWS calls (SSM, S3, Secrets Manager) against a real environment.
+
+## Prerequisites
+
+1. Node.js 22+
+2. AWS credentials configured for the target environment
+
+### AWS profiles by environment
+
+| Environment | AWS Profile                                                   |
+| ----------- | ------------------------------------------------------------- |
+| authdev3    | `di-authentication-development-AdministratorAccessPermission` |
+| staging     | `di-authentication-staging-ApprovedAdmin`                     |
+
+> **Staging access:** The staging profile requires a TEAM request. Once the request is
+> approved, run `authentication-api/scripts/set-up-sso.sh` to configure the profile locally.
+
+## Setup
+
+```bash
+npm install --save-dev puppeteer @aws-sdk/client-secrets-manager
+npx puppeteer browsers install chrome
+```
+
+## Usage
+
+Scripts are namespaced by environment:
+
+### authdev3
+
+```bash
+npm run canary:sign-in:authdev3
+npm run canary:create-account:authdev3
+npm run canary:sign-in-ipv:authdev3
+```
+
+### staging
+
+```bash
+npm run canary:sign-in:staging
+npm run canary:create-account:staging
+npm run canary:sign-in-ipv:staging
+```
+
+SSO login is handled automatically — if your session has expired, it will prompt you.
+
+### Environment variables
+
+Each script sets the following environment variables:
+
+| Variable             | Description                                     |
+| -------------------- | ----------------------------------------------- |
+| `DEPLOY_ENVIRONMENT` | Target environment (e.g. `authdev3`, `staging`) |
+| `CANARY_NAME`        | Canary identifier, matches SSM parameter prefix |
+| `AWS_PROFILE`        | AWS SSO profile for the target account          |
+| `AWS_REGION`         | AWS region (`eu-west-2`)                        |
+
+### Targeting a different environment manually
+
+Override the env vars directly:
+
+```bash
+DEPLOY_ENVIRONMENT=integration CANARY_NAME=integration-smoke-in AWS_PROFILE=di-authentication-integration-AdministratorAccessPermission AWS_REGION=eu-west-2 node local-testing/run.js canary-sign-in
+```
+
+The `CANARY_NAME` must match the SSM parameter prefix in that environment
+(e.g. `staging-smoke-in-username`, `staging-smoke-in-password`, etc.).
+
+## IPV canary behaviour
+
+The `canary-sign-in-with-ipv` canary is environment-aware:
+
+- **staging, integration, production** — asserts the IPV hand-off page loads
+- **dev, build, authdev3** — completes the sign-in flow and returns success without asserting IPV (IPV is not available in these environments)
+
+The canary still requests P2 confidence level (`vtr: '["P2.Cl.Cm"]'`) in all environments.
+
+## How It Works
+
+1. `local-testing/run.js` checks AWS credentials (triggers SSO login if expired)
+2. Mocks the `Synthetics` and `SyntheticsLogger` modules
+3. Launches a local Puppeteer/Chrome browser (ARM64-native on Apple Silicon)
+4. Requires your canary handler (e.g. `src/canary-sign-in.js`) and calls `handler()`
+5. The canary runs against the real environment using real SSM parameters and Secrets Manager
+
+## Limitations
+
+- No screenshots uploaded to S3 (could be added)
+- No CloudWatch metrics published
+- No HAR file capture
+- Not identical to the Lambda runtime (different Chrome version, no VPC)
+
+These are fine for development iteration. Use the deployed canary for production-accurate testing.
+
+## Troubleshooting
+
+| Problem                      | Solution                                                    |
+| ---------------------------- | ----------------------------------------------------------- |
+| Expired credentials          | Handled automatically; will prompt for SSO login            |
+| SSM parameter not found      | Check `CANARY_NAME` matches deployed SSM params             |
+| Chrome not found             | `npx puppeteer browsers install chrome`                     |
+| Wrong environment            | Use the correct `:env` suffixed script or set vars manually |
+| `DEPLOY_ENVIRONMENT` not set | Use the npm scripts which set this automatically            |

--- a/local-testing/run.js
+++ b/local-testing/run.js
@@ -1,0 +1,171 @@
+/**
+ * Local canary runner — executes canary handlers directly without the
+ * Synthetics Lambda layer. Mocks the Synthetics and SyntheticsLogger
+ * modules so the canary code runs on your Mac with real AWS calls
+ * (SSM, S3) but a local Puppeteer browser.
+ *
+ * Usage:
+ *   node local-testing/run.js canary-sign-in
+ *   node local-testing/run.js canary-create-account
+ *   node local-testing/run.js canary-sign-in-with-ipv
+ */
+
+const path = require("path");
+const https = require("https");
+const puppeteer = require("puppeteer");
+
+const canaryFile = process.argv[2];
+if (!canaryFile) {
+  throw new Error(
+    "Usage: node local-testing/run.js <canary-file>\n" +
+      "  e.g. node local-testing/run.js canary-sign-in"
+  );
+}
+
+const CANARY_NAME = process.env.CANARY_NAME || "authdev3-smoke-in";
+
+// --- Mock SyntheticsLogger ---
+const SyntheticsLogger = {
+  info: (...args) => console.log("[INFO]", ...args),
+  error: (...args) => console.error("[ERROR]", ...args),
+  warn: (...args) => console.warn("[WARN]", ...args),
+  write: (...args) => console.log("[LOG]", ...args),
+  reset: async () => {},
+  deleteLogFile: async () => {},
+};
+
+// --- Mock Synthetics ---
+let browser = null;
+let page = null;
+const stepErrors = [];
+
+const Synthetics = {
+  getCanaryName: () => CANARY_NAME,
+  getCanaryUserAgentString: () => `CloudWatchSynthetics/local ${CANARY_NAME}`,
+
+  getConfiguration: () => ({
+    setConfig: () => {},
+    withScreenshotOnStepStart: () => Synthetics.getConfiguration(),
+    withScreenshotOnStepSuccess: () => Synthetics.getConfiguration(),
+    withScreenshotOnStepFailure: () => Synthetics.getConfiguration(),
+  }),
+
+  getPage: async () => {
+    if (!page) {
+      browser = await puppeteer.launch({
+        headless: "new",
+        args: ["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage"],
+      });
+      page = await browser.newPage();
+    }
+    return page;
+  },
+
+  executeStep: async (stepName, fn) => {
+    console.log(`\n▶ Step: ${stepName}`);
+    try {
+      await fn();
+      console.log(`  ✓ ${stepName} passed`);
+    } catch (err) {
+      console.error(`  ✗ ${stepName} failed:`, err.message);
+      stepErrors.push({ stepName, error: err });
+      throw err;
+    }
+  },
+
+  executeHttpStep: async (stepName, requestOptions, callback, stepConfig) => {
+    console.log(`\n▶ HTTP Step: ${stepName}`);
+    try {
+      const res = await new Promise((resolve, reject) => {
+        const req = https.request(requestOptions, (res) => {
+          resolve(res);
+        });
+        req.on("error", reject);
+        req.end();
+      });
+      if (callback) {
+        const callbackResult = callback(res);
+        res.resume(); // drain body after callback has attached its 'end' listener
+        await callbackResult;
+      } else {
+        res.resume();
+      }
+      console.log(`  ✓ ${stepName} passed (${res.statusCode})`);
+    } catch (err) {
+      console.error(`  ✗ ${stepName} failed:`, err.message);
+      stepErrors.push({ stepName, error: err });
+      throw err;
+    }
+  },
+
+  getStepErrors: () => stepErrors,
+  getVisualMonitoringFailureOutsideStep: () => null,
+  addExecutionError: () => {},
+  reset: async () => {},
+  setEventAndContext: async () => {},
+  beforeCanary: async () => {},
+  launch: async () => {},
+  afterCanary: async () => {},
+};
+
+// --- Register mocks so require() finds them ---
+const Module = require("module");
+const originalResolve = Module._resolveFilename;
+Module._resolveFilename = function (request, ...args) {
+  if (request === "Synthetics") return "Synthetics";
+  if (request === "SyntheticsLogger") return "SyntheticsLogger";
+  return originalResolve.call(this, request, ...args);
+};
+
+require.cache["Synthetics"] = {
+  id: "Synthetics",
+  filename: "Synthetics",
+  loaded: true,
+  exports: Synthetics,
+};
+require.cache["SyntheticsLogger"] = {
+  id: "SyntheticsLogger",
+  filename: "SyntheticsLogger",
+  loaded: true,
+  exports: SyntheticsLogger,
+};
+
+// --- Ensure AWS credentials are valid ---
+const { execSync } = require("child_process");
+
+const AWS_PROFILE =
+  process.env.AWS_PROFILE ||
+  "di-authentication-development-AdministratorAccessPermission";
+process.env.AWS_PROFILE = AWS_PROFILE;
+process.env.AWS_REGION = process.env.AWS_REGION || "eu-west-2";
+
+try {
+  execSync(`aws sts get-caller-identity --profile ${AWS_PROFILE}`, {
+    stdio: "ignore",
+  });
+} catch {
+  console.log(`🔑 SSO session expired, logging in...`);
+  execSync(`aws sso login --profile ${AWS_PROFILE}`, { stdio: "inherit" });
+}
+
+// --- Run the canary ---
+async function main() {
+  console.log(`\n🔬 Running canary: ${canaryFile}`);
+  console.log(`   Canary name: ${CANARY_NAME}`);
+  console.log(`   Region: eu-west-2\n`);
+
+  const canaryPath = path.resolve(__dirname, "..", "src", canaryFile);
+  const canary = require(canaryPath);
+
+  try {
+    await canary.handler();
+    console.log("\n✅ Canary PASSED");
+  } catch (err) {
+    console.error("\n❌ Canary FAILED:", err.message);
+    process.exitCode = 1;
+  } finally {
+    if (browser) await browser.close();
+  }
+}
+
+main();

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,13 @@
         "express-openid-connect": "^2.18.1"
       },
       "devDependencies": {
+        "@aws-sdk/client-secrets-manager": "^3.1105.0",
         "@eslint/js": "^10.0.1",
         "eslint": "^10.8.0",
         "eslint-plugin-n": "^18.2.2",
         "globals": "^17.8.0",
-        "prettier": "^3.9.6"
+        "prettier": "^3.9.6",
+        "puppeteer": "^25.5.0"
       },
       "engines": {
         "node": "22.22.x",
@@ -65,6 +67,26 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-secrets-manager": {
+      "version": "3.1107.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1107.0.tgz",
+      "integrity": "sha512-eyVZ/9GXYFQxaKlOAdd9so/2hpZNhG+kMfv/pE5tZaE7G1u4XZBpebPX/OhQJXEppbbGv9cc3lrpfcO9slBYFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-ssm": {
       "version": "3.1098.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1098.0.tgz",
@@ -85,9 +107,9 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.977.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.4.tgz",
-      "integrity": "sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==",
+      "version": "3.977.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
+      "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
@@ -113,12 +135,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.65",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.65.tgz",
-      "integrity": "sha512-lJT2aRw9wCV8jPHyFJjdZLD4HTydL6/22AnCSOB8e/LqOc55nEJGLHkJQeSxhn8QiqyjFwPKQFtMw0ovjRUY/g==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
+      "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -129,12 +151,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.67.tgz",
-      "integrity": "sha512-N7fw/15hSwI/CPxe5ohOyb7O4ge9f5me1gVIn8OIkBRB0squ8OJqQyDyH/HoL+Sb1W5xdC88jVC+bHkw73iu+Q==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
+      "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
@@ -147,19 +169,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.10.tgz",
-      "integrity": "sha512-Zh9XRaPnDN9buO7GfWBubS22R6Nq5D6hbyYEMN05LiOnXugm/8WDjUx6y756bSPbdn3aJB2qG4zFW3bN82QhoQ==",
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
+      "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/credential-provider-env": "^3.972.65",
-        "@aws-sdk/credential-provider-http": "^3.972.67",
-        "@aws-sdk/credential-provider-login": "^3.972.72",
-        "@aws-sdk/credential-provider-process": "^3.972.65",
-        "@aws-sdk/credential-provider-sso": "^3.973.9",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.71",
-        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-login": "^3.972.74",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
@@ -171,13 +193,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.72",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.72.tgz",
-      "integrity": "sha512-zZapIKwaHp7TdTf9hbH1I3CVUdEupmt7FXO/BoTQGC+4h6NkXKWpqF2p5WyfpjurDLHCpSyh+BzMlAg8arqWLA==",
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
+      "integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -188,17 +210,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.76",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.76.tgz",
-      "integrity": "sha512-1yzLmRiYSgGC25v7ZZEwJn/auhHHTIHgFOmzL2f36hf1+7jSLcX+1QrAz4760WEzPiiQl8xmlpFhHfl2OoyVzA==",
+      "version": "3.972.78",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
+      "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.65",
-        "@aws-sdk/credential-provider-http": "^3.972.67",
-        "@aws-sdk/credential-provider-ini": "^3.973.10",
-        "@aws-sdk/credential-provider-process": "^3.972.65",
-        "@aws-sdk/credential-provider-sso": "^3.973.9",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.71",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-ini": "^3.973.12",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
@@ -210,12 +232,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.65",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.65.tgz",
-      "integrity": "sha512-e5DbbNteOSalN58U83G6kFa4ECLEuGbGqNBHIXE7zYXA/m4GHblIGjFbSH7wYv6gBV8iNSDcRZBKfQZF5vF9nw==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
+      "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -226,14 +248,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.9.tgz",
-      "integrity": "sha512-0V0u4t+KBku9fbh5CPCaC5hUWwSzDafp8nCuDy817zWbp2gz80jO44rMQkiwnZ+k54B+tjAtzRy00DJRGTKGBg==",
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
+      "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
-        "@aws-sdk/token-providers": "3.1100.0",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/token-providers": "3.1103.0",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -244,13 +266,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.71",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.71.tgz",
-      "integrity": "sha512-e4dwiRltGAaQ+2yxw57Hj0l/BF3BHiG14+QpYE7bGYBlpAq/fkIri2BDhjWon8c0mhhtd2txQBAkQb9BcTStFg==",
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
+      "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -278,12 +300,12 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.39.tgz",
-      "integrity": "sha512-wU5NPnj62Sb7A8xn/Zb+xThe05P3otNtDl37iOIi5DDMeCesNeCckaG+eXWGUs12Z9R34I8CD05TaTe6SIa61g==",
+      "version": "3.997.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
+      "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/signature-v4-multi-region": "^3.996.43",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
@@ -312,13 +334,13 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1100.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1100.0.tgz",
-      "integrity": "sha512-THf3MkgY3fNJZ3zdgSenLqR7gSE68KccCj1RCKretlG73Ppszvues02VpCUO9NlB/tZDC483FvGCld+AiPCkvg==",
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
+      "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -605,6 +627,35 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@puppeteer/browsers": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.2.0.tgz",
+      "integrity": "sha512-LlBrE8oqGfU7b1Nk2d5Q1SbuPhZxTj0cJEMDPEws28OjNMELlflekmPPuf4FnK03x0ZRjKaYwJElUcKK4kyqJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "modern-tar": "^0.8.0",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "browsers": "lib/main-cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "proxy-agent": ">=8.0.1",
+        "yauzl": "^2.10.0 || ^3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "proxy-agent": {
+          "optional": true
+        },
+        "yauzl": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -848,6 +899,32 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -1089,6 +1166,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chromium-bidi": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-17.0.2.tgz",
+      "integrity": "sha512-5v9GQFhTktFvotn/OFNJBmKLKRAb6n9r0bVCwf7sHgWc3/JryK0bj1nn93L3pHFrfgcsu6Be6EWsDi+1XHTGDg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=20.19.0 <22.0.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -1096,6 +1190,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/clone": {
@@ -1328,6 +1455,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1653615",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1653615.tgz",
+      "integrity": "sha512-pGVkY3T/qXxAp2nFPodwYqOevk6ncNMSmvL8QfRCx5ZWGd6Vor7AFNmyaA8Zs6uJyP1QAfjuLandCgvSix1BNA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1346,6 +1480,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -1514,6 +1655,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -2069,6 +2220,29 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2877,6 +3051,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -2998,6 +3185,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/modern-tar": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.8.4.tgz",
+      "integrity": "sha512-gN54ddmyzEg10orwZ2u4OOv+bjpMWdIl5jIkodK97bMq8QBSL5c0D7YX0lT1Ooz+99S7+PvFbnxzdjgHo1r41g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/ms": {
@@ -3346,6 +3550,46 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.6.0.tgz",
+      "integrity": "sha512-TXUolDddU4AwISjOOrGk2AhJDpbM/ZDt2KvGIqz74EOk+8bKwXFo+acUvP1sQx3hUda7owOeNuuT1UnJT1o0qA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.2.0",
+        "chromium-bidi": "17.0.2",
+        "devtools-protocol": "0.0.1653615",
+        "lilconfig": "^3.1.3",
+        "puppeteer-core": "25.6.0",
+        "typed-query-selector": "^2.12.2"
+      },
+      "bin": {
+        "puppeteer": "lib/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.6.0.tgz",
+      "integrity": "sha512-GJ67rjZdVQzZmD2Ab0cgttfQN9j387QYMv3t6MN3/4nmjursNt6M5Utj4/T/4y0AwNrSwJzjw6Q/zuWFEIizOg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.2.0",
+        "chromium-bidi": "17.0.2",
+        "devtools-protocol": "0.0.1653615",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.2",
+        "ws": "^8.21.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/qs": {
@@ -3770,6 +4014,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/string.prototype.trim": {
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
@@ -3824,6 +4085,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/tapable": {
@@ -3973,6 +4250,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -4039,6 +4323,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
+      "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -4151,17 +4442,113 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+      "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^8.2.1",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -4174,6 +4561,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,13 @@
     "build:all": "npm run build:synthetics && npm run build:alerts && npm run build:heartbeat && npm run build:slack",
     "pretty": "prettier --write \"**/*.{js,json}\"",
     "check-pretty": "prettier --check \"**/*.{js,json}\"",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "canary:sign-in:authdev3": "DEPLOY_ENVIRONMENT=authdev3 CANARY_NAME=authdev3-smoke-in AWS_PROFILE=di-authentication-development-AdministratorAccessPermission AWS_REGION=eu-west-2 node local-testing/run.js canary-sign-in",
+    "canary:create-account:authdev3": "DEPLOY_ENVIRONMENT=authdev3 CANARY_NAME=authdev3-smoke-cra AWS_PROFILE=di-authentication-development-AdministratorAccessPermission AWS_REGION=eu-west-2 node local-testing/run.js canary-create-account",
+    "canary:sign-in-ipv:authdev3": "DEPLOY_ENVIRONMENT=authdev3 CANARY_NAME=authdev3-smoke-ipv AWS_PROFILE=di-authentication-development-AdministratorAccessPermission AWS_REGION=eu-west-2 node local-testing/run.js canary-sign-in-with-ipv",
+    "canary:sign-in:staging": "DEPLOY_ENVIRONMENT=staging CANARY_NAME=staging-smoke-in AWS_PROFILE=di-authentication-staging-ApprovedAdmin AWS_REGION=eu-west-2 node local-testing/run.js canary-sign-in",
+    "canary:create-account:staging": "DEPLOY_ENVIRONMENT=staging CANARY_NAME=staging-smoke-cra AWS_PROFILE=di-authentication-staging-ApprovedAdmin AWS_REGION=eu-west-2 node local-testing/run.js canary-create-account",
+    "canary:sign-in-ipv:staging": "DEPLOY_ENVIRONMENT=staging CANARY_NAME=staging-smoke-ipv AWS_PROFILE=di-authentication-staging-ApprovedAdmin AWS_REGION=eu-west-2 node local-testing/run.js canary-sign-in-with-ipv"
   },
   "prettier": {
     "trailingComma": "es5",
@@ -39,10 +45,12 @@
     "joi": ">=17.13.4"
   },
   "devDependencies": {
+    "@aws-sdk/client-secrets-manager": "^3.1105.0",
     "@eslint/js": "^10.0.1",
     "eslint": "^10.8.0",
     "eslint-plugin-n": "^18.2.2",
     "globals": "^17.8.0",
-    "prettier": "^3.9.6"
+    "prettier": "^3.9.6",
+    "puppeteer": "^25.5.0"
   }
 }

--- a/src/canary-sign-in-with-ipv.js
+++ b/src/canary-sign-in-with-ipv.js
@@ -24,6 +24,12 @@ const basicCustomEntryPoint = async () => {
     throw "Sign in with IPV smoke test failed due to Fire Drill";
   }
 
+  const environment = process.env.DEPLOY_ENVIRONMENT;
+  const ipvAvailable = ["staging", "integration", "production"].includes(
+    environment
+  );
+  log.info(`Environment: ${environment}, IPV available: ${ipvAvailable}`);
+
   const bucketName = await getParameter("bucket");
   const email = await getParameter("username");
   const password = await getParameter("password");
@@ -79,7 +85,13 @@ const basicCustomEntryPoint = async () => {
 
   await steps.skipPasskeyPromptIfPresent(page);
 
-  await steps.ipvHandOff(page);
+  if (ipvAvailable) {
+    await steps.ipvHandOff(page);
+  } else {
+    log.info(
+      "IPV not available in this environment — sign-in completed successfully"
+    );
+  }
 
   return "success";
 };

--- a/template.yaml
+++ b/template.yaml
@@ -964,6 +964,8 @@ Resources:
         TimeoutInSeconds: 60
         MemoryInMB: 1024
         ActiveTracing: false
+        EnvironmentVariables:
+          DEPLOY_ENVIRONMENT: !Ref Environment
       Code:
         S3Bucket:
           !FindInMap [


### PR DESCRIPTION
  
## What

- Add local canary runner for testing Synthetics smoke tests
- Modify the Sign-in with IPV test to complete successfully in enviroments where IPV is not deployed (so that the rest of the canary can be tested locally and in dev)

Add a lightweight local runner that executes Synthetics canary handlers directly on the developer's machine without Docker or the Lambda layer.

- local-testing/run.js: Mocks the Synthetics and SyntheticsLogger modules, launches a native Puppeteer/Chrome browser, and invokes the canary handler.  Automatically handles SSO login if credentials have expired.
- local-testing/README.md: Setup instructions and usage documentation.
- package.json: Added npm scripts (canary:sign-in:authdev3, canary:create-account:authdev3, canary:sign-in-ipv:authdev3, canary:sign-in:staging, canary:create-account:staging, canary:sign-in-ipv:staging) and dev dependencies (puppeteer, @aws-sdk/client-secrets-manager).

The canary runs against a real environment (default: authdev3) using SSM parameters for test config and S3 for OTP codes. Target other environments by setting CANARY_NAME and AWS_PROFILE env vars.

Provides a facility to build and test smoketests against a remote environment.  After the split in theory Orchestration could only be available in staging if we don't continue to support authdev3.  And if we build smoketests including AMC journeys they would only be testable in staging.

AWS does provide a way to [run canaries locally](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Debug_Locally.html) but there appear to be issues using the Docker image on Apple Silicon which produced segmentation faults when running.  Arguably the approach in this PR is simpler.

## How to review

1. Code Review
1. Follow instructions in the readme to run the smoketests locally

## Related PRs

