### PR TITLE
BAU: Skip passkey prompt in IPV canary

### DIFF
--- a/src/canary-sign-in-with-ipv.js
+++ b/src/canary-sign-in-with-ipv.js
@@ -77,6 +77,8 @@ const basicCustomEntryPoint = async () => {
 
   await steps.submitOtpCode(page);
 
+  await steps.skipPasskeyPromptIfPresent(page);
+
   await steps.ipvHandOff(page);
 
   return "success";


### PR DESCRIPTION
## What

Executes the standard canary-sign-in-with-ipv journey, adding a new step to skip the passkey prompt if it's present. We already do this in the other canaries.

## How to review

1. Code Review