### PR TITLE
BAU: Suppress `ElastiCache:ServiceUpdate*` alerts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         pass_filenames: false
       - id: eslint
         name: Run ESLint
-        language: node
+        language: system
         types_or:
           - javascript
           - ts

--- a/alerts/alerts.js
+++ b/alerts/alerts.js
@@ -1,12 +1,12 @@
 const { getParameter } = require("./aws");
 
 const isSuppressedAlert = (snsMessage) => {
-  if (
-    JSON.stringify(snsMessage).includes("ElastiCache") &&
-    snsMessage["ElastiCache:ServiceUpdateAvailable"]
-  ) {
+  const elasticacheServiceUpdateKey = Object.keys(snsMessage).find((key) =>
+    key.startsWith("ElastiCache:ServiceUpdate")
+  );
+  if (elasticacheServiceUpdateKey) {
     console.log(
-      `Suppressing ElastiCache ServiceUpdateAvailable notification for cluster: ${snsMessage["ElastiCache:ServiceUpdateAvailable"]}`
+      `Suppressing ${elasticacheServiceUpdateKey} notification for cluster: ${snsMessage[elasticacheServiceUpdateKey]}`
     );
     return true;
   }

--- a/alerts/test/alerts.test.js
+++ b/alerts/test/alerts.test.js
@@ -238,6 +238,31 @@ describe("alerts handler", () => {
       expect(result.body).to.equal("Alert suppressed");
     });
 
+    it("should suppress ElastiCache ServiceUpdateAvailableForNode notifications", async () => {
+      fetchStub.resolves({ text: () => Promise.resolve("ok") });
+
+      const snsMessage = {
+        "Service Update Name": "elasticache-20260608-intel",
+        "Replication Group ID": "production-sessions-store",
+        "ElastiCache:ServiceUpdateAvailableForNode":
+          "production-sessions-store",
+      };
+
+      const event = {
+        Records: [
+          {
+            Sns: { Type: "Notification", Message: JSON.stringify(snsMessage) },
+          },
+        ],
+      };
+
+      const result = await handler(event, {});
+
+      expect(fetchStub).to.not.have.been.called;
+      expect(result.statusCode).to.equal(200);
+      expect(result.body).to.equal("Alert suppressed");
+    });
+
     it("should not suppress other ElastiCache notifications", async () => {
       fetchStub.resolves({ text: () => Promise.resolve("ok") });
 
@@ -292,6 +317,16 @@ describe("alerts handler", () => {
         "Service Update Name": "elasticache-20260608-intel",
         "Replication Group ID": "production-sessions-store",
         "ElastiCache:ServiceUpdateAvailable": "production-sessions-store",
+      };
+      expect(isSuppressedAlert(message)).to.be.true;
+    });
+
+    it("should return true for ServiceUpdateAvailableForNode messages", () => {
+      const message = {
+        "Service Update Name": "elasticache-20260608-intel",
+        "Replication Group ID": "production-sessions-store",
+        "ElastiCache:ServiceUpdateAvailableForNode":
+          "production-sessions-store",
       };
       expect(isSuppressedAlert(message)).to.be.true;
     });


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

Broadens the ElastiCache alert suppression to match any `ElastiCache:ServiceUpdate*` key prefix instead of only the exact `ServiceUpdateAvailable` key.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to authdev3 with `./sam-deploy-authdevs.sh`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code Review

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

https://github.com/govuk-one-login/authentication-smoke-tests/pull/1322