### PR TITLE
BAU: Add dependency cooldown period for subprojects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,8 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "0 3 1,15 * *"
+    cooldown:
+      default-days: 7
     groups:
       npm-aws-dependencies:
         patterns:
@@ -40,6 +42,8 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "0 3 1,15 * *"
+    cooldown:
+      default-days: 7
     groups:
       npm-chai-dependencies:
         patterns:
@@ -54,6 +58,8 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "0 3 1,15 * *"
+    cooldown:
+      default-days: 7
     groups:
       npm-aws-dependencies:
         patterns:
@@ -71,6 +77,8 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "0 3 1,15 * *"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     groups:
       gha-all-dependencies:


### PR DESCRIPTION
The cooldown at the root (/) does not apply to subprojects

