### PR TITLE
BAU: Remove setup-java and setup-gradle github actions from pre-commit.yml

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,18 +17,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: 🏗️ Set up JDK 17
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 #v5.6.0
-        with:
-          java-version: "17"
-          distribution: "corretto"
-
-      - name: 🏗️ Set up Gradle
-        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
-        with:
-          cache-read-only: false
-          add-job-summary: never
-
       - name: 🏗️ Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:


### PR DESCRIPTION
## What

Remove setup-java and setup-gradle github actions from pre-commit.yml

Java and Gradle are not used in the smoke tests

## How to review

1. Code Review
1. Check that the pre-commit github action runs correctly

