### PR TITLE
BAU: Upgrade GitHub Actions to support Node.js 24

### DIFF
--- a/.github/workflows/build-and-deploy-dev.yml
+++ b/.github/workflows/build-and-deploy-dev.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up SAM cli
-        uses: aws-actions/setup-sam@89ddb14d60e682855e3fea4be85b3c56485de310 # v2
+        uses: aws-actions/setup-sam@89ddb14d60e682855e3fea4be85b3c56485de310 # v3
         with:
           use-installer: true
           version: 1.159.1

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up SAM cli
-        uses: aws-actions/setup-sam@89ddb14d60e682855e3fea4be85b3c56485de310 # v2
+        uses: aws-actions/setup-sam@89ddb14d60e682855e3fea4be85b3c56485de310 # v3
         with:
           use-installer: true
           version: 1.159.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -24,7 +24,7 @@ jobs:
           distribution: "corretto"
 
       - name: 🏗️ Set up Gradle
-        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
           cache-read-only: false
           add-job-summary: never
@@ -41,7 +41,7 @@ jobs:
           cache: "npm"
 
       - name: 🏗️ Set up SAM CLI
-        uses: aws-actions/setup-sam@89ddb14d60e682855e3fea4be85b3c56485de310 # v2
+        uses: aws-actions/setup-sam@89ddb14d60e682855e3fea4be85b3c56485de310 # v3
         with:
           use-installer: true
           version: 1.159.1
@@ -49,9 +49,19 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
-      - name: Run pre-commit
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      - name: Install pre-commit
+        run: |
+          python -m pip install pre-commit
+          python -m pip freeze --local
+
+      - name: Cache pre-commit hooks
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
-          extra_args: |
+          path: ~/.cache/pre-commit
+          key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Run pre-commit
+        run: |
+          pre-commit run --show-diff-on-failure --color=always \
             --from-ref "${{ github.event.pull_request.base.sha }}" \
             --to-ref "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/pre-merge-checks-sam.yml
+++ b/.github/workflows/pre-merge-checks-sam.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up SAM cli
-        uses: aws-actions/setup-sam@89ddb14d60e682855e3fea4be85b3c56485de310 # v2
+        uses: aws-actions/setup-sam@89ddb14d60e682855e3fea4be85b3c56485de310 # v3
         with:
           use-installer: true
 


### PR DESCRIPTION

## What

Upgrade GitHub Actions to support Node.js 24

- Replace pre-commit/action@v3.0.1 with inline steps using actions/cache@v5.1.0. The pre-commit/action is in maintenance-only mode and its latest release still depends on actions/cache@v4 which targets Node.js 20.
- Update gradle/actions/setup-gradle from v6.2.0 to v6.3.0
- Fix aws-actions/setup-sam version comment from v2 to v3 (SHA was already pointing to the v3/node24 release)

Resolves Node.js 20 deprecation warnings.

## How to review

1. Code Review
1. Check that all actions have completed correctly without deprecation warnings
